### PR TITLE
Custom Context

### DIFF
--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -364,7 +364,7 @@ export class Snap {
 		let globalContext: ContextVariables = {};
 		try {
 			// get global context
-			globalContext = getContext(['shopper', 'config', 'merchandising', 'siteId', 'currency']);
+			globalContext = getContext(['shopper', 'config', 'custom', 'merchandising', 'siteId', 'currency']);
 		} catch (err) {
 			console.error('Snap failed to find global context');
 		}


### PR DESCRIPTION
* adding `custom` to getContext

Need a way to get custom context without having to utilize `getContext` outside of templates. This change aligns with `custom` used for recommendation script context support:
https://github.com/searchspring/snap-1.0/blob/main/packages/snap-preact/src/Instantiators/RecommendationInstantiator.tsx#L174