### PR TITLE
Theme Merge Fix

### DIFF
--- a/packages/snap-preact/components/src/components/Atoms/Button/Button.tsx
+++ b/packages/snap-preact/components/src/components/Atoms/Button/Button.tsx
@@ -84,8 +84,6 @@ export const Button = observer((properties: ButtonProps): JSX.Element => {
 		icon: {
 			className: 'ss__button__icon',
 			// default props
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Carousel/Carousel.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Carousel/Carousel.tsx
@@ -246,8 +246,6 @@ export const Carousel = observer((properties: CarouselProps): JSX.Element => {
 		icon: {
 			// default props
 			className: 'ss__carousel__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Checkbox/Checkbox.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Checkbox/Checkbox.tsx
@@ -61,8 +61,6 @@ export const Checkbox = observer((properties: CheckboxProps): JSX.Element => {
 			// default props
 			className: 'ss__checkbox__icon',
 			icon: 'check-thin',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				color: iconColor || color || theme?.variables?.colors?.primary,

--- a/packages/snap-preact/components/src/components/Molecules/ErrorHandler/ErrorHandler.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/ErrorHandler/ErrorHandler.tsx
@@ -135,8 +135,6 @@ export const ErrorHandler = observer((properties: ErrorHandlerProps): JSX.Elemen
 			// default props
 			size: '18px',
 			className: 'ss__error-handler__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -149,8 +147,6 @@ export const ErrorHandler = observer((properties: ErrorHandlerProps): JSX.Elemen
 			// default props
 			className: 'ss__error-handler__button',
 			icon: 'rotate-right',
-			// global theme
-			...globalTheme?.components?.button,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/FacetListOptions/FacetListOptions.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/FacetListOptions/FacetListOptions.tsx
@@ -59,8 +59,6 @@ export const FacetListOptions = observer((properties: FacetListOptionsProps): JS
 		checkbox: {
 			// default props
 			className: 'ss__facet-list-options__checkbox',
-			// global theme
-			...globalTheme?.components?.checkbox,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/FacetPaletteOptions/FacetPaletteOptions.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/FacetPaletteOptions/FacetPaletteOptions.tsx
@@ -193,8 +193,6 @@ export const FacetPaletteOptions = observer((properties: FacetPaletteOptionsProp
 		icon: {
 			// default props
 			className: 'ss__facet-palette-options__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -209,8 +207,6 @@ export const FacetPaletteOptions = observer((properties: FacetPaletteOptionsProp
 		checkbox: {
 			// default props
 			className: 'ss__facet-palette-options__checkbox',
-			// global theme
-			...globalTheme?.components?.checkbox,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/FacetToggle/FacetToggle.tsx.nope
+++ b/packages/snap-preact/components/src/components/Molecules/FacetToggle/FacetToggle.tsx.nope
@@ -34,8 +34,6 @@ export const FacetToggle = observer((properties: FacetToggleProps): JSX.Element 
 	const subProps: FacetToggleSubProps = {
 		Toggle: {
 			// default props
-			// global theme
-			...globalTheme?.components?.toggle,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Filter/Filter.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Filter/Filter.tsx
@@ -51,8 +51,6 @@ export const Filter = observer((properties: FilterProps): JSX.Element => {
 		button: {
 			// default props
 			className: 'ss__filter__button',
-			// global theme
-			...globalTheme?.components?.button,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -66,8 +64,6 @@ export const Filter = observer((properties: FilterProps): JSX.Element => {
 			icon: 'close-thin',
 			className: 'ss__filter__button__icon',
 			size: '10px',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Grid/Grid.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Grid/Grid.tsx
@@ -148,8 +148,6 @@ export function Grid(properties: GridProps): JSX.Element {
 		image: {
 			// default props
 			className: 'ss__grid__image',
-			// global theme
-			...globalTheme?.components?.image,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/LayoutSelector/LayoutSelector.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/LayoutSelector/LayoutSelector.tsx
@@ -40,8 +40,6 @@ export const LayoutSelector = observer((properties: LayoutSelectorProps): JSX.El
 
 	const subProps: SelectSubProps = {
 		Select: {
-			// global theme
-			...globalTheme?.components?.select,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -51,8 +49,6 @@ export const LayoutSelector = observer((properties: LayoutSelectorProps): JSX.El
 			treePath,
 		},
 		RadioList: {
-			// global theme
-			...globalTheme?.components?.radioList,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -66,8 +62,6 @@ export const LayoutSelector = observer((properties: LayoutSelectorProps): JSX.El
 			horizontal: true,
 			hideOptionCheckboxes: true,
 			requireSelection: true,
-			// global theme
-			...globalTheme?.components?.list,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/LoadMore/LoadMore.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/LoadMore/LoadMore.tsx
@@ -111,8 +111,6 @@ export const LoadMore = observer((properties: LoadMoreProps): JSX.Element => {
 				{ 'ss__load-more__button--hidden': isLoading && loadingLocation === 'outside' },
 				{ 'ss__load-more__button--disabled': isButtonDisabled }
 			),
-			// global theme
-			...globalTheme?.components?.button,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -124,8 +122,6 @@ export const LoadMore = observer((properties: LoadMoreProps): JSX.Element => {
 		icon: {
 			// default props
 			className: 'ss__load-more__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Pagination/Pagination.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Pagination/Pagination.tsx
@@ -64,8 +64,6 @@ export const Pagination = observer((properties: PaginationProps): JSX.Element =>
 			// default props
 			className: 'ss__pagination__icon',
 			size: '10px',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/PerPage/PerPage.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/PerPage/PerPage.tsx
@@ -42,8 +42,6 @@ export const PerPage = observer((properties: PerPageProps): JSX.Element => {
 
 	const subProps: SelectSubProps = {
 		select: {
-			// global theme
-			...globalTheme?.components?.select,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -53,8 +51,6 @@ export const PerPage = observer((properties: PerPageProps): JSX.Element => {
 			treePath,
 		},
 		RadioList: {
-			// global theme
-			...globalTheme?.components?.radioList,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -67,8 +63,6 @@ export const PerPage = observer((properties: PerPageProps): JSX.Element => {
 			multiSelect: false,
 			hideOptionCheckboxes: true,
 			horizontal: true,
-			// global theme
-			...globalTheme?.components?.list,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Radio/Radio.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Radio/Radio.tsx
@@ -69,8 +69,6 @@ export const Radio = observer((properties: RadioProps): JSX.Element => {
 			name: 'active',
 			// default props
 			className: 'ss__radio__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				size,
@@ -85,8 +83,6 @@ export const Radio = observer((properties: RadioProps): JSX.Element => {
 			name: 'inactive',
 			// default props
 			className: 'ss__radio__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				size,

--- a/packages/snap-preact/components/src/components/Molecules/Rating/Rating.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Rating/Rating.tsx
@@ -56,8 +56,6 @@ export const Rating = observer((properties: RatingProps): JSX.Element => {
 		fullIcon: {
 			name: 'star--full',
 			// default props
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -70,8 +68,6 @@ export const Rating = observer((properties: RatingProps): JSX.Element => {
 			name: 'star--empty',
 			// default props
 			color: '#ccc',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
@@ -104,8 +104,6 @@ export const Result = observer((properties: ResultProps): JSX.Element => {
 		price: {
 			// global theme
 			className: 'ss__result__price',
-			...globalTheme?.components?.price,
-			// inherited props
 			...defined({
 				disableStyles,
 			}),
@@ -117,8 +115,6 @@ export const Result = observer((properties: ResultProps): JSX.Element => {
 			// default props
 			className: 'ss__result__callout-badge',
 			result,
-			// global theme
-			...globalTheme?.components?.calloutBadge,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -132,8 +128,6 @@ export const Result = observer((properties: ResultProps): JSX.Element => {
 			className: 'ss__result__overlay-badge',
 			result,
 			controller: controller as SearchController | AutocompleteController | RecommendationController,
-			// global theme
-			...globalTheme?.components?.overlayBadge,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -147,8 +141,6 @@ export const Result = observer((properties: ResultProps): JSX.Element => {
 			className: 'ss__result__image',
 			alt: core?.name || '',
 			src: core?.imageUrl || '',
-			// global theme
-			...globalTheme?.components?.image,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/SearchInput/SearchInput.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/SearchInput/SearchInput.tsx
@@ -46,8 +46,6 @@ export const SearchInput = observer((properties: SearchInputProps): JSX.Element 
 		icon: {
 			// default props
 			className: 'ss__search-input__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Select/Select.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Select/Select.tsx
@@ -117,8 +117,6 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 	const subProps: SelectSubProps = {
 		dropdown: {
 			className: 'ss__select__dropdown',
-			// global theme
-			...globalTheme?.components?.dropdown,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -131,8 +129,6 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 		button: {
 			// default props
 			className: 'ss__select__dropdown__button',
-			// global theme
-			...globalTheme?.components?.button,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -148,8 +144,6 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 		icon: {
 			// default props
 			className: 'ss__select__dropdown__button__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Slideout/Slideout.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Slideout/Slideout.tsx
@@ -60,8 +60,6 @@ export const Slideout = observer((properties: SlideoutProps): JSX.Element => {
 		overlay: {
 			// default props
 			className: 'ss__slideout__overlay',
-			// global theme
-			...globalTheme?.components?.overlay,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/SortBy/SortBy.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/SortBy/SortBy.tsx
@@ -42,8 +42,6 @@ export const SortBy = observer((properties: SortByProps): JSX.Element => {
 
 	const subProps: SelectSubProps = {
 		Select: {
-			// global theme
-			...globalTheme?.components?.select,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -53,8 +51,6 @@ export const SortBy = observer((properties: SortByProps): JSX.Element => {
 			treePath,
 		},
 		RadioList: {
-			// global theme
-			...globalTheme?.components?.radioList,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -67,8 +63,6 @@ export const SortBy = observer((properties: SortByProps): JSX.Element => {
 			multiSelect: false,
 			hideOptionCheckboxes: true,
 			horizontal: true,
-			// global theme
-			...globalTheme?.components?.list,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/Swatches/Swatches.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Swatches/Swatches.tsx
@@ -117,8 +117,6 @@ export function Swatches(properties: SwatchesProps): JSX.Element {
 			className: 'ss__swatches__carousel',
 			loop: false,
 			...carousel,
-			// global theme
-			...globalTheme?.components?.carousel,
 			// inherited props
 			...defined({
 				breakpoints,
@@ -137,8 +135,6 @@ export function Swatches(properties: SwatchesProps): JSX.Element {
 			rows: 1,
 			columns: 6,
 			...grid,
-			// global theme
-			...globalTheme?.components?.grid,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -150,8 +146,6 @@ export function Swatches(properties: SwatchesProps): JSX.Element {
 		image: {
 			// default props
 			className: 'ss__swatches__image',
-			// global theme
-			...globalTheme?.components?.image,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Molecules/VariantSelection/VariantSelection.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/VariantSelection/VariantSelection.tsx
@@ -77,8 +77,6 @@ export const VariantSelection = observer((properties: VariantSelectionProps): JS
 			className: 'ss__variant-selection__dropdown',
 			// TODO: label doesnt exist on dropdown?
 			// label: selection.label || selection.field,
-			// global theme
-			...globalTheme?.components?.dropdown,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -91,8 +89,6 @@ export const VariantSelection = observer((properties: VariantSelectionProps): JS
 			// default props
 			className: 'ss__variant-selection__icon',
 			size: '12px',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -108,9 +104,6 @@ export const VariantSelection = observer((properties: VariantSelectionProps): JS
 			hideOptionCheckboxes: true,
 			onSelect: (e, option) => selection.select(option.value),
 			selected: selection.selected,
-
-			// global theme
-			...globalTheme?.components?.list,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -123,8 +116,6 @@ export const VariantSelection = observer((properties: VariantSelectionProps): JS
 			className: 'ss__variant-selection__swatches',
 			onSelect: (e, option) => selection.select(option.value),
 			selected: selection.selected,
-			// global theme
-			...globalTheme?.components?.swatches,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/BranchOverride/BranchOverride.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/BranchOverride/BranchOverride.tsx
@@ -260,8 +260,6 @@ export const BranchOverride = (properties: BranchOverrideProps): JSX.Element => 
 			// default props
 			className: 'ss__branch-override__bottom__left__icon',
 			size: '12px',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
@@ -114,8 +114,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 			className: 'ss__facet__dropdown',
 			disableClickOutside: true,
 			disableOverlay: true,
-			// global theme
-			...globalTheme?.components?.dropdown,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -129,8 +127,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 			className: 'ss__facet__dropdown__icon',
 			size: '12px',
 			color: iconColor || color,
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -144,8 +140,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 			className: 'ss__facet__show-more-less__icon',
 			size: '10px',
 			color: iconColor || color,
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -157,8 +151,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 		facetHierarchyOptions: {
 			// default props
 			className: 'ss__facet__facet-hierarchy-options',
-			// global theme
-			...globalTheme?.components?.facetHierarchyOptions,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -173,8 +165,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 		facetListOptions: {
 			// default props
 			className: 'ss__facet__facet-list-options',
-			// global theme
-			...globalTheme?.components?.facetListOptions,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -189,8 +179,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 		facetGridOptions: {
 			// default props
 			className: 'ss__facet__facet-grid-options',
-			// global theme
-			...globalTheme?.components?.facetGridOptions,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -205,8 +193,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 		facetPaletteOptions: {
 			// default props
 			className: 'ss__facet__facet-palette-options',
-			// global theme
-			...globalTheme?.components?.facetPaletteOptions,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -221,8 +207,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 		// facetToggle: {
 		// 	// default props
 		// 	className: 'ss__facet__facet-toggle',
-		// 	// global theme
-		// 	...globalTheme?.components?.facetToggle,
 		// 	// inherited props
 		// 	...defined({
 		// 		disableStyles,
@@ -234,8 +218,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 		facetSlider: {
 			// default props
 			className: 'ss__facet__facet-slider',
-			// global theme
-			...globalTheme?.components?.facetSlider,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -247,8 +229,6 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 		searchInput: {
 			// default props
 			className: 'ss__facet__search-input',
-			// global theme
-			...globalTheme?.components?.searchInput,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/Facets/Facets.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Facets/Facets.tsx
@@ -70,8 +70,6 @@ export const Facets = observer((properties: FacetsProps): JSX.Element => {
 		facet: {
 			// default props
 			className: 'ss__facets__facet',
-			// global theme
-			...globalTheme?.components?.facet,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/FacetsHorizontal/FacetsHorizontal.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/FacetsHorizontal/FacetsHorizontal.tsx
@@ -154,8 +154,6 @@ export const FacetsHorizontal = observer((properties: FacetsHorizontalProps): JS
 			disableClickOutside: true,
 			disableOverlay: true,
 			disableA11y: true,
-			// global theme
-			...globalTheme?.components?.dropdown,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -167,8 +165,6 @@ export const FacetsHorizontal = observer((properties: FacetsHorizontalProps): JS
 		icon: {
 			// default props
 			className: 'ss__dropdown__button__heading__icon',
-			// global theme
-			...globalTheme?.components?.icon,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -182,8 +178,6 @@ export const FacetsHorizontal = observer((properties: FacetsHorizontalProps): JS
 			className: `ss__facets-horizontal__content__facet`,
 			justContent: true,
 			// horizontal: true,
-			// global theme
-			...globalTheme?.components?.facet,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -198,8 +192,6 @@ export const FacetsHorizontal = observer((properties: FacetsHorizontalProps): JS
 			className: 'ss__facets-horizontal__header__mobile-sidebar',
 			hidePerPage: true,
 			hideSortBy: true,
-			// global theme
-			...globalTheme?.components?.mobileSidebar,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/FilterSummary/FilterSummary.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/FilterSummary/FilterSummary.tsx
@@ -63,8 +63,6 @@ export const FilterSummary = observer((properties: FilterSummaryProps): JSX.Elem
 			name: 'filter',
 			// default props
 			className: 'ss__filter-summary__filter',
-			// global theme
-			...globalTheme?.components?.filter,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/MobileSidebar/MobileSidebar.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/MobileSidebar/MobileSidebar.tsx
@@ -104,8 +104,6 @@ export const MobileSidebar = observer((properties: MobileSidebarProps): JSX.Elem
 			// default props
 			controller,
 			displayAt: (displayAt && `(max-width: ${displayAt})`) || '',
-			// global theme
-			...globalTheme?.components?.slideout,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -116,8 +114,6 @@ export const MobileSidebar = observer((properties: MobileSidebarProps): JSX.Elem
 		},
 		button: {
 			// default props
-			// global theme
-			...globalTheme?.components?.button,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -133,8 +129,6 @@ export const MobileSidebar = observer((properties: MobileSidebarProps): JSX.Elem
 			hidePerPage: hidePerPage,
 			hideSortBy: hideSortBy,
 			hideFilterSummary: hideFilterSummary,
-			// global theme
-			...globalTheme?.components?.sidebar,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/Results/Results.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Results/Results.tsx
@@ -99,8 +99,6 @@ export const Results = observer((properties: ResultsProps): JSX.Element => {
 		result: {
 			// default props
 			className: 'ss__results__result',
-			// global theme
-			...globalTheme?.components?.result,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -112,8 +110,6 @@ export const Results = observer((properties: ResultsProps): JSX.Element => {
 		inlineBanner: {
 			// default props
 			className: 'ss__results__inline-banner',
-			// global theme
-			...globalTheme?.components?.inlineBanner,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/Sidebar/Sidebar.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Sidebar/Sidebar.tsx
@@ -36,8 +36,6 @@ export const Sidebar = observer((properties: SidebarProps): JSX.Element => {
 		filterSummary: {
 			// default props
 			controller,
-			// global theme
-			...globalTheme?.components?.filterSummary,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -49,8 +47,6 @@ export const Sidebar = observer((properties: SidebarProps): JSX.Element => {
 		facets: {
 			// default props
 			controller,
-			// global theme
-			...globalTheme?.components?.facets,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -62,8 +58,6 @@ export const Sidebar = observer((properties: SidebarProps): JSX.Element => {
 		sortBy: {
 			// default props
 			controller,
-			// global theme
-			...globalTheme?.components?.sortBy,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -75,8 +69,6 @@ export const Sidebar = observer((properties: SidebarProps): JSX.Element => {
 		perPage: {
 			// default props
 			controller,
-			// global theme
-			...globalTheme?.components?.perPage,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Organisms/Toolbar/Toolbar.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Toolbar/Toolbar.tsx
@@ -49,8 +49,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__mobile-sidebar',
-			// global theme
-			...globalTheme?.components?.mobileSidebar,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -63,8 +61,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__filter-summary',
-			// global theme
-			...globalTheme?.components?.filterSummary,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -77,8 +73,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__layout-selector',
-			// global theme
-			...globalTheme?.components?.layoutSelector,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -91,8 +85,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__pagination',
-			// global theme
-			...globalTheme?.components?.pagination,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -105,8 +97,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__pagination-info',
-			// global theme
-			...globalTheme?.components?.paginationInfo,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -119,8 +109,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__load-more',
-			// global theme
-			...globalTheme?.components?.loadMore,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -133,8 +121,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__sort-by',
-			// global theme
-			...globalTheme?.components?.sortBy,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -147,8 +133,6 @@ export const Toolbar = observer((properties: ToolbarProps): JSX.Element => {
 			// default props
 			controller,
 			className: 'ss__toolbar__per-page',
-			// global theme
-			...globalTheme?.components?.perPage,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Templates/RecommendationBundle/BundleCTA.tsx
+++ b/packages/snap-preact/components/src/components/Templates/RecommendationBundle/BundleCTA.tsx
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 import { cloneWithProps } from '../../../utilities';
 import { Button, ButtonProps } from '../../Atoms/Button';
 import { Price, PriceProps } from '../../Atoms/Price';
-import { Theme, useTheme } from '../../../providers';
 import { Icon, IconProps, IconType } from '../../Atoms/Icon';
 import type { ComponentProps } from '../../../types';
 import type { CartStore } from '@searchspring/snap-store-mobx';
@@ -14,8 +13,6 @@ import { Lang, useLang } from '../../../hooks';
 import deepmerge from 'deepmerge';
 
 export const BundledCTA = observer((properties: BundledCTAProps): JSX.Element => {
-	const globalTheme: Theme = useTheme();
-
 	const props: BundledCTAProps = {
 		// default props
 		// global theme
@@ -42,8 +39,6 @@ export const BundledCTA = observer((properties: BundledCTAProps): JSX.Element =>
 			// default props
 			className: 'ss__recommendation-bundle__wrapper__cta__icon',
 			size: 50,
-			// global theme
-			...globalTheme?.components?.icon,
 			// component theme overrides
 			theme: props?.theme,
 			treePath,
@@ -51,8 +46,6 @@ export const BundledCTA = observer((properties: BundledCTAProps): JSX.Element =>
 		subtotalStrike: {
 			// default props
 			name: 'bundle-msrp',
-			// global theme
-			...globalTheme?.components?.price,
 			// component theme overrides
 			theme: props?.theme,
 			treePath,
@@ -60,16 +53,12 @@ export const BundledCTA = observer((properties: BundledCTAProps): JSX.Element =>
 		subtotalPrice: {
 			// default props
 			name: 'bundle-price',
-			// global theme
-			...globalTheme?.components?.price,
 			// component theme overrides
 			theme: props?.theme,
 			treePath,
 		},
 		button: {
 			// default props
-			// global theme
-			...globalTheme?.components?.button,
 			// component theme overrides
 			theme: props?.theme,
 			treePath,

--- a/packages/snap-preact/components/src/components/Templates/RecommendationBundle/BundleSelector.tsx
+++ b/packages/snap-preact/components/src/components/Templates/RecommendationBundle/BundleSelector.tsx
@@ -29,8 +29,6 @@ export const BundleSelector = observer((properties: BundleSelectorProps): JSX.El
 			name: 'bundle-selector',
 			className: 'ss__recommendation-bundle__wrapper__selector__icon',
 			size: 15,
-			// global theme
-			...globalTheme?.components?.icon,
 			// component theme overrides
 			theme: props?.theme,
 			treePath: modifiedTreePath,
@@ -47,8 +45,6 @@ export const BundleSelector = observer((properties: BundleSelectorProps): JSX.El
 					},
 				},
 			},
-			// global theme
-			...globalTheme?.components?.checkbox,
 			// component theme overrides
 			theme: props?.theme,
 			treePath: modifiedTreePath,

--- a/packages/snap-preact/components/src/components/Templates/RecommendationBundle/RecommendationBundle.tsx
+++ b/packages/snap-preact/components/src/components/Templates/RecommendationBundle/RecommendationBundle.tsx
@@ -160,8 +160,6 @@ export const RecommendationBundle = observer((properties: RecommendationBundlePr
 		ctaButtonSuccessTimeout: 2000,
 		ctaInline: true,
 		onAddToCart: (e, items) => controller?.addToCart && controller.addToCart(items),
-		// global theme
-		...globalTheme?.components?.recommendationBundle,
 		...properties,
 		// props
 		...properties.theme?.components?.recommendationBundle,
@@ -257,8 +255,6 @@ export const RecommendationBundle = observer((properties: RecommendationBundlePr
 			loop: loop,
 			// default props
 			className: 'ss__recommendation__carousel',
-			// global theme
-			...globalTheme?.components?.carousel,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -270,8 +266,6 @@ export const RecommendationBundle = observer((properties: RecommendationBundlePr
 		result: {
 			// default props
 			className: 'ss__recommendation__result',
-			// global theme
-			...globalTheme?.components?.result,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/components/Templates/RecommendationGrid/RecommendationGrid.tsx
+++ b/packages/snap-preact/components/src/components/Templates/RecommendationGrid/RecommendationGrid.tsx
@@ -68,8 +68,6 @@ export const RecommendationGrid = observer((properties: RecommendationGridProps)
 		result: {
 			// default props
 			className: 'ss__recommendation-grid__result',
-			// global theme
-			...globalTheme?.components?.result,
 			// inherited props
 			...defined({
 				disableStyles,

--- a/packages/snap-preact/components/src/themes/bocachica/components/organisms/results.ts
+++ b/packages/snap-preact/components/src/themes/bocachica/components/organisms/results.ts
@@ -8,12 +8,8 @@ import type { ResultsProps } from '../../../../components/Organisms/Results';
 
 // Results component props
 export const results: ThemeComponentProps<ResultsProps> = {
-	default: {
-		// themeStyleScript: resultsStyleScript,
-	},
-	mobile: {
-		columns: 5,
-	},
+	default: {},
+	mobile: {},
 	tablet: {},
 	desktop: {},
 };

--- a/packages/snap-preact/components/src/themes/bocachica/components/templates/autocomplete.ts
+++ b/packages/snap-preact/components/src/themes/bocachica/components/templates/autocomplete.ts
@@ -46,10 +46,6 @@ const autocompleteStyleScript = ({
 				flex: vertical ? '0 1 150px' : undefined,
 			},
 
-			'.ss__facet-palette-options, .ss__facet-grid-options': {
-				gridTemplateColumns: 'repeat(auto-fill, minmax(36px, 1fr))',
-			},
-
 			'.ss__facet__options': {
 				maxHeight: '250px',
 			},
@@ -81,7 +77,7 @@ export const autocomplete: ThemeComponentProps<AutocompleteProps> = {
 					disableCollapse: true,
 				},
 				facets: {
-					limit: 2,
+					limit: 3,
 				},
 				facetGridOptions: {
 					columns: 3,

--- a/packages/snap-preact/components/src/themes/bocachica/components/templates/search.ts
+++ b/packages/snap-preact/components/src/themes/bocachica/components/templates/search.ts
@@ -42,6 +42,9 @@ export const search: ThemeComponentProps<SearchProps> = {
 		},
 		theme: {
 			components: {
+				results: {
+					columns: 5,
+				},
 				filterSummary: {
 					hideTitle: true,
 				},

--- a/packages/snap-preact/components/src/utilities/mergeProps.test.ts
+++ b/packages/snap-preact/components/src/utilities/mergeProps.test.ts
@@ -353,7 +353,6 @@ describe('mergeProps function with theme name', () => {
 					[componentType]: {
 						// @ts-ignore - different prop value
 						startOpen: '2',
-						unrelatedProp: 2,
 					},
 					otherComponent: {
 						shouldNotExist: 2,
@@ -366,7 +365,7 @@ describe('mergeProps function with theme name', () => {
 		expect(props).toStrictEqual({
 			...defaultProps,
 			...properties,
-			startOpen: '1',
+			startOpen: '2',
 			unrelatedProp: 1,
 			theme: {
 				name: globalTheme.name,

--- a/packages/snap-preact/components/src/utilities/mergeProps.ts
+++ b/packages/snap-preact/components/src/utilities/mergeProps.ts
@@ -20,10 +20,10 @@ export function mergeProps<GenericComponentProps = ComponentProps>(
 		
 		1. start with default props
 		2. spreads standard props (directly passed via JSX) - these may be provided by the integration or sub-props
-		3. spreads global theme props of component and named component
-		4. spreads component theme props of component and named component
+		3. spreads component theme props of component and named component
+		4. spreads global theme props of component and named component
 		5. ensure templates theme variables pass on in `theme`
-		6. if treepath contains 'custom' do 2 again
+		6. if treepath contains 'custom' do #2 again
 
 	*/
 
@@ -66,31 +66,19 @@ export function mergeProps<GenericComponentProps = ComponentProps>(
 
 		treePath += componentName?.match(/^[A-Z,a-z,-]+$/) ? `.${componentName}` : '';
 
-		// add theme props if they exist
-		const themeComponent = theme?.components && theme.components[componentType as keyof typeof theme.components];
-		if (themeComponent) {
-			mergedProps = mergeThemeProps(themeComponent, mergedProps) as Partial<GenericComponentProps>;
-		}
-
-		// add theme props for components with selector matches if they exist
-		const themeApplicableSelectors = filterSelectors(theme?.components || {}, treePath).sort(sortSelectors);
-		themeApplicableSelectors.forEach((selector) => {
-			const componentProps = theme?.components?.[selector as keyof typeof globalTheme.components];
+		// add globalTheme props for components with selector matches if they exist
+		const globalApplicableSelectors = filterSelectors(globalTheme?.components || {}, treePath).sort(sortSelectors);
+		globalApplicableSelectors.forEach((selector) => {
+			const componentProps = globalTheme.components?.[selector as keyof typeof globalTheme.components];
 			if (componentProps) {
 				mergedProps = mergeThemeProps(componentProps, mergedProps) as Partial<GenericComponentProps>;
 			}
 		});
 
-		// add globalTheme props if they exist
-		const globalComponent = globalTheme?.components && globalTheme.components[componentType as keyof typeof globalTheme.components];
-		if (globalComponent) {
-			mergedProps = mergeThemeProps(globalComponent, mergedProps) as Partial<GenericComponentProps>;
-		}
-
-		// add globalTheme props for components with selector matches if they exist
-		const globalApplicableSelectors = filterSelectors(globalTheme?.components || {}, treePath).sort(sortSelectors);
-		globalApplicableSelectors.forEach((selector) => {
-			const componentProps = globalTheme.components?.[selector as keyof typeof globalTheme.components];
+		// add theme props for components with selector matches if they exist
+		const themeApplicableSelectors = filterSelectors(theme?.components || {}, treePath).sort(sortSelectors);
+		themeApplicableSelectors.forEach((selector) => {
+			const componentProps = theme?.components?.[selector as keyof typeof globalTheme.components];
 			if (componentProps) {
 				mergedProps = mergeThemeProps(componentProps, mergedProps) as Partial<GenericComponentProps>;
 			}


### PR DESCRIPTION
* removing ALL instances where globalTheme is being spread in subprops of components (this is redundant in mergeProps)
* separating overrides from base theme in ThemeStore and applying overrides selectively to the props.themes found
* adjusting Bocachica theme with applicable changes
* **BONUS:** adding `theme` getter as a computed (for memoization)