### PR TITLE
Templates Identifier

### DIFF
--- a/packages/snap-client/src/Client/Client.test.ts
+++ b/packages/snap-client/src/Client/Client.test.ts
@@ -2,7 +2,7 @@ import 'whatwg-fetch';
 import { Client } from './Client';
 import type { ClientConfig } from '../types';
 import { MockData } from '@searchspring/snap-shared';
-import { AppMode } from '@searchspring/snap-toolbox';
+import { AppMode, version } from '@searchspring/snap-toolbox';
 
 const mockData = new MockData();
 
@@ -199,11 +199,11 @@ describe('Snap Client', () => {
 					noBeacon: true,
 				},
 			};
-			const acCacheKey = '{"siteId":["8uyt2m"],"redirectResponse":"full","ajaxCatalog":"Snap","resultsFormat":"native"}';
+			const acCacheKey = `{"siteId":["8uyt2m"],"redirectResponse":"full","ajaxCatalog":"snap/client/${version}","resultsFormat":"native"}`;
 
 			expect(acRequesterSpy).toHaveBeenCalledTimes(1);
 			expect(acRequesterSpy.mock.calls).toEqual([
-				[{ ...acRequest, query: { ajaxCatalog: 'Snap', ...acRequest.query } }, acCacheKey], // first call
+				[{ ...acRequest, query: { ajaxCatalog: `snap/client/${version}`, ...acRequest.query } }, acCacheKey], // first call
 			]);
 
 			expect(fetchApiMock).toHaveBeenCalledTimes(3);
@@ -271,10 +271,10 @@ describe('Snap Client', () => {
 				headers: {},
 				method: 'GET',
 				path: '/api/search/search.json',
-				query: { resultsFormat: 'native', siteId: ['8uyt2m'], noBeacon: true, ajaxCatalog: 'Snap' },
+				query: { resultsFormat: 'native', siteId: ['8uyt2m'], noBeacon: true, ajaxCatalog: `snap/client/${version}` },
 			};
 
-			const searchcacheKey = '{"siteId":["8uyt2m"],"ajaxCatalog":"Snap","resultsFormat":"native"}';
+			const searchcacheKey = `{"siteId":["8uyt2m"],"ajaxCatalog":"snap/client/${version}","resultsFormat":"native"}`;
 
 			expect(searchRequesterSpy).toHaveBeenCalledTimes(1);
 			expect(searchRequesterSpy.mock.calls).toEqual([[searchparams, searchcacheKey]]);
@@ -455,11 +455,11 @@ describe('Snap Client', () => {
 						noBeacon: true,
 					},
 				};
-				const acCacheKey = '{"siteId":["8uyt2m"],"redirectResponse":"full","ajaxCatalog":"Snap","resultsFormat":"native"}';
+				const acCacheKey = `{"siteId":["8uyt2m"],"redirectResponse":"full","ajaxCatalog":"snap/client/${version}","resultsFormat":"native"}`;
 
 				expect(acRequesterSpy).toHaveBeenCalledTimes(1);
 				expect(acRequesterSpy.mock.calls).toEqual([
-					[{ ...acRequest, query: { ajaxCatalog: 'Snap', ...acRequest.query } }, acCacheKey], // first call
+					[{ ...acRequest, query: { ajaxCatalog: `snap/client/${version}`, ...acRequest.query } }, acCacheKey], // first call
 				]);
 
 				expect(fetchApiMock).toHaveBeenCalledTimes(3);
@@ -522,10 +522,59 @@ describe('Snap Client', () => {
 					headers: {},
 					method: 'GET',
 					path: '/api/search/search.json',
-					query: { resultsFormat: 'native', siteId: ['8uyt2m'], noBeacon: true, ajaxCatalog: 'Snap' },
+					query: { resultsFormat: 'native', siteId: ['8uyt2m'], noBeacon: true, ajaxCatalog: `snap/client/${version}` },
 				};
 
-				const searchcacheKey = '{"siteId":["8uyt2m"],"ajaxCatalog":"Snap","resultsFormat":"native"}';
+				const searchcacheKey = `{"siteId":["8uyt2m"],"ajaxCatalog":"snap/client/${version}","resultsFormat":"native"}`;
+
+				expect(searchRequesterSpy).toHaveBeenCalledTimes(1);
+				expect(searchRequesterSpy.mock.calls).toEqual([[searchparams, searchcacheKey]]);
+
+				const metaRequest = {
+					headers: {},
+					method: 'GET',
+					path: '/api/meta/meta.json',
+					query: {
+						siteId: '8uyt2m',
+					},
+				};
+
+				const metaCacheKey = '{"siteId":"8uyt2m"}';
+
+				expect(metaRequesterSpy).toHaveBeenCalledTimes(1);
+				expect(metaRequesterSpy.mock.calls).toEqual([[metaRequest, metaCacheKey]]);
+
+				expect(fetchApiMock).toHaveBeenCalledTimes(2);
+				fetchApiMock.mockReset();
+			});
+
+			it('Search method with custom fetchApi with custom initiator', async () => {
+				const fetchApiMock = jest.fn(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
+
+				const client = new Client({ siteId: '8uyt2m' }, { mode: 'development', initiator: 'snap/development', fetchApi: fetchApiMock });
+
+				//@ts-ignore
+				const searchRequester = client.requesters.search.requesters.legacy;
+
+				const searchRequesterSpy = jest.spyOn(searchRequester, 'request' as never);
+
+				//@ts-ignore
+				const metaRequester = client.requesters.meta.requesters.legacy;
+
+				const metaRequesterSpy = jest.spyOn(metaRequester, 'request' as never);
+
+				const searchprops = { siteId: '8uyt2m' };
+
+				await client.search(searchprops);
+
+				const searchparams = {
+					headers: {},
+					method: 'GET',
+					path: '/api/search/search.json',
+					query: { resultsFormat: 'native', siteId: ['8uyt2m'], noBeacon: true, ajaxCatalog: 'snap/development' },
+				};
+
+				const searchcacheKey = `{"siteId":["8uyt2m"],"ajaxCatalog":"snap/development","resultsFormat":"native"}`;
 
 				expect(searchRequesterSpy).toHaveBeenCalledTimes(1);
 				expect(searchRequesterSpy.mock.calls).toEqual([[searchparams, searchcacheKey]]);

--- a/packages/snap-client/src/Client/Client.ts
+++ b/packages/snap-client/src/Client/Client.ts
@@ -76,6 +76,7 @@ export class Client {
 			autocomplete: new HybridAPI(
 				new ApiConfiguration({
 					fetchApi: this.config.fetchApi,
+					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.autocomplete?.origin,
 					headers: this.config.autocomplete?.headers,
@@ -87,6 +88,7 @@ export class Client {
 			meta: new HybridAPI(
 				new ApiConfiguration({
 					fetchApi: this.config.fetchApi,
+					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.meta?.origin,
 					headers: this.config.meta?.headers,
@@ -97,6 +99,7 @@ export class Client {
 			recommend: new RecommendAPI(
 				new ApiConfiguration({
 					fetchApi: this.config.fetchApi,
+					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.recommend?.origin,
 					headers: this.config.recommend?.headers,
@@ -107,6 +110,7 @@ export class Client {
 			search: new HybridAPI(
 				new ApiConfiguration({
 					fetchApi: this.config.fetchApi,
+					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.search?.origin,
 					headers: this.config.search?.headers,
@@ -117,6 +121,7 @@ export class Client {
 			finder: new HybridAPI(
 				new ApiConfiguration({
 					fetchApi: this.config.fetchApi,
+					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.finder?.origin,
 					headers: this.config.finder?.headers,
@@ -127,6 +132,7 @@ export class Client {
 			suggest: new SuggestAPI(
 				new ApiConfiguration({
 					fetchApi: this.config.fetchApi,
+					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.suggest?.origin,
 					headers: this.config.suggest?.headers,

--- a/packages/snap-client/src/Client/apis/Abstract.ts
+++ b/packages/snap-client/src/Client/apis/Abstract.ts
@@ -1,5 +1,5 @@
 import deepmerge from 'deepmerge';
-import { AppMode } from '@searchspring/snap-toolbox';
+import { AppMode, version } from '@searchspring/snap-toolbox';
 
 import { fibonacci } from '../utils/fibonacci';
 import { NetworkCache } from '../NetworkCache/NetworkCache';
@@ -144,6 +144,7 @@ export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export interface ApiConfigurationParameters {
 	mode?: keyof typeof AppMode | AppMode;
+	initiator?: string;
 	origin?: string; // override url origin
 	fetchApi?: FetchAPI; // override for fetch implementation
 	queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
@@ -177,6 +178,10 @@ export class ApiConfiguration {
 
 	get origin(): string {
 		return this.config.origin || '';
+	}
+
+	get initiator(): string {
+		return this.config.initiator || `snap/client/${version}`;
 	}
 
 	get fetchApi(): FetchAPI {

--- a/packages/snap-client/src/Client/apis/Hybrid.test.ts
+++ b/packages/snap-client/src/Client/apis/Hybrid.test.ts
@@ -2,6 +2,7 @@ import 'whatwg-fetch';
 import { ApiConfiguration } from './Abstract';
 import { HybridAPI } from './Hybrid';
 import { MockData } from '@searchspring/snap-shared';
+import { version } from '@searchspring/snap-toolbox';
 
 const mockData = new MockData();
 
@@ -54,7 +55,7 @@ describe('Hybrid Api', () => {
 			headers: {},
 			method: 'GET',
 		};
-		const fetchUrl = 'https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&noBeacon=true&ajaxCatalog=Snap&resultsFormat=native';
+		const fetchUrl = `https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&noBeacon=true&ajaxCatalog=snap%2Fclient%2F${version}&resultsFormat=native`;
 
 		await api.getSearch({
 			siteId: '8uyt2m',

--- a/packages/snap-client/src/Client/apis/Hybrid.ts
+++ b/packages/snap-client/src/Client/apis/Hybrid.ts
@@ -26,6 +26,7 @@ export class HybridAPI extends API {
 		const legacyConfig: ApiConfigurationParameters = deepmerge(
 			{
 				mode: this.configuration.mode,
+				initiator: this.configuration.initiator,
 				origin: this.configuration.origin,
 				cache: this.configuration.cache,
 				fetchApi: this.configuration.fetchApi,
@@ -40,6 +41,7 @@ export class HybridAPI extends API {
 		const suggestConfig: ApiConfigurationParameters = deepmerge(
 			{
 				mode: this.configuration.mode,
+				initiator: this.configuration.initiator,
 				origin: this.configuration.origin,
 				cache: this.configuration.cache,
 				fetchApi: this.configuration.fetchApi,

--- a/packages/snap-client/src/Client/apis/Legacy.test.ts
+++ b/packages/snap-client/src/Client/apis/Legacy.test.ts
@@ -1,6 +1,7 @@
 import 'whatwg-fetch';
 import { ApiConfiguration } from './Abstract';
 import { LegacyAPI } from './Legacy';
+import { version } from '@searchspring/snap-toolbox';
 
 describe('Legacy Api', () => {
 	it('has expected default functions', () => {
@@ -47,7 +48,7 @@ describe('Legacy Api', () => {
 			headers: {},
 			method: 'GET',
 		};
-		const requestUrl = 'https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&q=dress&ajaxCatalog=Snap&resultsFormat=native';
+		const requestUrl = `https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&q=dress&ajaxCatalog=snap%2Fclient%2F${version}&resultsFormat=native`;
 
 		await api.getSearch({
 			siteId: '8uyt2m',
@@ -89,7 +90,7 @@ describe('Legacy Api', () => {
 			headers: {},
 			method: 'GET',
 		};
-		const requestUrl = 'https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&q=dress&ajaxCatalog=Snap&resultsFormat=native';
+		const requestUrl = `https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&q=dress&ajaxCatalog=snap%2Fclient%2F${version}&resultsFormat=native`;
 
 		await api.getAutocomplete({
 			siteId: '8uyt2m',
@@ -109,7 +110,7 @@ describe('Legacy Api', () => {
 			headers: {},
 			method: 'GET',
 		};
-		const requestUrl = 'https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&q=dress&ajaxCatalog=Snap&resultsFormat=native';
+		const requestUrl = `https://8uyt2m.a.searchspring.io/api/search/search.json?siteId=8uyt2m&q=dress&ajaxCatalog=snap%2Fclient%2F${version}&resultsFormat=native`;
 
 		await api.getFinder({
 			siteId: '8uyt2m',

--- a/packages/snap-client/src/Client/apis/Legacy.ts
+++ b/packages/snap-client/src/Client/apis/Legacy.ts
@@ -63,17 +63,17 @@ export class LegacyAPI extends API {
 	}
 
 	async getSearch(queryParameters: any): Promise<any> {
-		queryParameters.ajaxCatalog = 'Snap';
+		queryParameters.ajaxCatalog = this.configuration.initiator;
 		return this.getEndpoint(queryParameters, '/api/search/search.json');
 	}
 
 	async getAutocomplete(queryParameters: any): Promise<any> {
-		queryParameters.ajaxCatalog = 'Snap';
+		queryParameters.ajaxCatalog = this.configuration.initiator;
 		return this.getEndpoint(queryParameters, '/api/search/autocomplete.json');
 	}
 
 	async getFinder(queryParameters: any): Promise<any> {
-		queryParameters.ajaxCatalog = 'Snap';
+		queryParameters.ajaxCatalog = this.configuration.initiator;
 		return this.getEndpoint(queryParameters, '/api/search/finder.json');
 	}
 }

--- a/packages/snap-client/src/types.ts
+++ b/packages/snap-client/src/types.ts
@@ -18,6 +18,7 @@ type RequesterConfig<T> = {
 
 export type ClientConfig = {
 	mode?: keyof typeof AppMode | AppMode;
+	initiator?: string;
 	fetchApi?: WindowOrWorkerGlobalScope['fetch'];
 	meta?: RequesterConfig<MetaRequestModel>;
 	search?: RequesterConfig<SearchRequestModel>;

--- a/packages/snap-preact/src/Snap.test.tsx
+++ b/packages/snap-preact/src/Snap.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, waitFor } from '@testing-library/preact';
 import { MockClient } from '@searchspring/snap-shared';
 import { Tracker, TrackerGlobals } from '@searchspring/snap-tracker';
 import { Logger } from '@searchspring/snap-logger';
-import { cookies } from '@searchspring/snap-toolbox';
+import { cookies, version } from '@searchspring/snap-toolbox';
 
 import type { SearchControllerConfig, AutocompleteControllerConfig } from '@searchspring/snap-controller';
 
@@ -242,6 +242,7 @@ describe('Snap Preact', () => {
 		// snap passes the app mode down to the client config
 		const extendedBaseConfig = { ...baseConfig };
 		extendedBaseConfig.client!.config = {
+			initiator: `snap/preact/${version}`,
 			mode: 'production',
 		};
 
@@ -294,6 +295,7 @@ describe('Snap Preact', () => {
 		// snap passes the app mode down to the client config
 		const extendedBaseConfig = { ...baseConfig };
 		extendedBaseConfig.client!.config = {
+			initiator: `snap/preact/${version}`,
 			mode: 'development',
 		};
 

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -362,7 +362,7 @@ export class Snap {
 				},
 			};
 
-			this.config.client = deepmerge(this.config.client || {}, defaultClientConfig);
+			this.config.client = deepmerge(defaultClientConfig, this.config.client || {});
 		}
 
 		if ((!services?.client || !services?.tracker) && !this.config?.client?.globals?.siteId) {
@@ -391,6 +391,7 @@ export class Snap {
 		if (services?.templatesStore) {
 			this.templates = services.templatesStore;
 		}
+
 		try {
 			const urlParams = url(window.location.href);
 			const branchOverride = urlParams?.params?.query[BRANCH_PARAM] || cookies.get(BRANCH_COOKIE);
@@ -426,6 +427,7 @@ export class Snap {
 			// client mode uses client config over snap config
 			if (this.config.client) {
 				this.config.client.config = this.config.client.config || {};
+				this.config.client.config.initiator = `snap/preact/${version}`;
 				this.config.client.config.mode = this.config.client.config.mode || this.mode;
 			}
 
@@ -449,7 +451,7 @@ export class Snap {
 				});
 			}
 
-			const trackerConfig = deepmerge(this.config.tracker?.config || {}, { framework: 'snap/preact', mode: this.mode });
+			const trackerConfig = deepmerge({ framework: 'snap/preact', mode: this.mode }, this.config.tracker?.config || {});
 			this.tracker = services?.tracker || new Tracker(trackerGlobals, trackerConfig);
 
 			// log version

--- a/packages/snap-preact/src/Templates/SnapTemplates.tsx
+++ b/packages/snap-preact/src/Templates/SnapTemplates.tsx
@@ -4,7 +4,7 @@ import deepmerge from 'deepmerge';
 import { Snap } from '../Snap';
 import { TemplateSelect } from '../../components/src/components/Atoms/TemplateSelect';
 
-import { DomTargeter, url, cookies, getContext } from '@searchspring/snap-toolbox';
+import { DomTargeter, url, cookies, getContext, version } from '@searchspring/snap-toolbox';
 import { TemplateTarget, TemplatesStore } from './Stores/TemplateStore';
 
 import type { Target } from '@searchspring/snap-toolbox';
@@ -356,6 +356,14 @@ export function createSnapConfig(templateConfig: SnapTemplatesConfig, templatesS
 		client: {
 			globals: {
 				siteId: templateConfig.config?.siteId,
+			},
+			config: {
+				initiator: `snap/templates/${version}`,
+			},
+		},
+		tracker: {
+			config: {
+				framework: 'snap/templates',
 			},
 		},
 		instantiators: {},


### PR DESCRIPTION
* adding specific values for `ajaxCatalog` when sending to the Search API
* changing Beacon API initiator context value when sending via Snap Templates
* changes required adding additional configuration to the Snap Client (initiator)
* default value in the Snap Client for initiator only occurs when hitting the Search API (legacy requester)