### PR TITLE
Adding Client Config

### DIFF
--- a/packages/snap-client/src/Client/Client.ts
+++ b/packages/snap-client/src/Client/Client.ts
@@ -102,6 +102,7 @@ export class Client {
 					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.recommend?.origin,
+					alternateOrigin: this.config.recommend?.alternateOrigin,
 					headers: this.config.recommend?.headers,
 					cache: this.config.recommend?.cache,
 					globals: this.config.recommend?.globals,

--- a/packages/snap-client/src/Client/Client.ts
+++ b/packages/snap-client/src/Client/Client.ts
@@ -102,7 +102,7 @@ export class Client {
 					initiator: this.config.initiator,
 					mode: this.mode,
 					origin: this.config.recommend?.origin,
-					alternateOrigin: this.config.recommend?.alternateOrigin,
+					secondaryOrigin: this.config.recommend?.secondaryOrigin,
 					headers: this.config.recommend?.headers,
 					cache: this.config.recommend?.cache,
 					globals: this.config.recommend?.globals,

--- a/packages/snap-client/src/Client/apis/Abstract.ts
+++ b/packages/snap-client/src/Client/apis/Abstract.ts
@@ -147,7 +147,7 @@ export interface ApiConfigurationParameters {
 	mode?: keyof typeof AppMode | AppMode;
 	initiator?: string;
 	origin?: string; // override url origin
-	alternateOrigin?: string; // override url origin
+	secondaryOrigin?: string; // override url origin
 	fetchApi?: FetchAPI; // override for fetch implementation
 	queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
 	headers?: HTTPHeaders; //header params we want to use on every request
@@ -182,8 +182,8 @@ export class ApiConfiguration {
 		return this.config.origin || '';
 	}
 
-	get alternateOrigin(): string {
-		return this.config.alternateOrigin || '';
+	get secondaryOrigin(): string {
+		return this.config.secondaryOrigin || '';
 	}
 
 	get initiator(): string {

--- a/packages/snap-client/src/Client/apis/Abstract.ts
+++ b/packages/snap-client/src/Client/apis/Abstract.ts
@@ -18,6 +18,7 @@ export interface RequestOpts {
 	headers: HTTPHeaders;
 	query?: HTTPQuery;
 	body?: HTTPBody;
+	origin?: string; // override url origin
 }
 
 export class API {
@@ -105,7 +106,7 @@ export class API {
 		}
 
 		const siteIdHost = `https://${siteId}.a.searchspring.io`;
-		const origin = (this.configuration.origin || siteIdHost).replace(/\/$/, '');
+		const origin = (context.origin || this.configuration.origin || siteIdHost).replace(/\/$/, '');
 
 		let url = `${origin}/${context.path.replace(/^\//, '')}`;
 
@@ -146,6 +147,7 @@ export interface ApiConfigurationParameters {
 	mode?: keyof typeof AppMode | AppMode;
 	initiator?: string;
 	origin?: string; // override url origin
+	alternateOrigin?: string; // override url origin
 	fetchApi?: FetchAPI; // override for fetch implementation
 	queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
 	headers?: HTTPHeaders; //header params we want to use on every request
@@ -178,6 +180,10 @@ export class ApiConfiguration {
 
 	get origin(): string {
 		return this.config.origin || '';
+	}
+
+	get alternateOrigin(): string {
+		return this.config.alternateOrigin || '';
 	}
 
 	get initiator(): string {

--- a/packages/snap-client/src/Client/apis/Recommend.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.ts
@@ -43,7 +43,7 @@ export class RecommendAPI extends API {
 		const response = await this.request<ProfileResponseModel>(
 			{
 				path: '/api/personalized-recommendations/profile.json',
-				origin: this.configuration.alternateOrigin || undefined, // use alternate origin for profile requests
+				origin: this.configuration.secondaryOrigin || undefined, // use alternate origin for profile requests
 				method: 'GET',
 				headers: headerParameters,
 				query: queryParameters,

--- a/packages/snap-client/src/Client/apis/Recommend.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.ts
@@ -43,7 +43,7 @@ export class RecommendAPI extends API {
 		const response = await this.request<ProfileResponseModel>(
 			{
 				path: '/api/personalized-recommendations/profile.json',
-				origin: this.configuration.alternateOrigin, // use alternate origin for profile requests
+				origin: this.configuration.alternateOrigin || undefined, // use alternate origin for profile requests
 				method: 'GET',
 				headers: headerParameters,
 				query: queryParameters,

--- a/packages/snap-client/src/Client/apis/Recommend.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.ts
@@ -43,6 +43,7 @@ export class RecommendAPI extends API {
 		const response = await this.request<ProfileResponseModel>(
 			{
 				path: '/api/personalized-recommendations/profile.json',
+				origin: this.configuration.alternateOrigin, // use alternate origin for profile requests
 				method: 'GET',
 				headers: headerParameters,
 				query: queryParameters,

--- a/packages/snap-client/src/types.ts
+++ b/packages/snap-client/src/types.ts
@@ -11,6 +11,7 @@ export type HTTPHeaders = { [key: string]: string };
 
 type RequesterConfig<T> = {
 	origin?: string;
+	alternateOrigin?: string;
 	headers?: HTTPHeaders;
 	cache?: CacheConfig;
 	globals?: Partial<T>;

--- a/packages/snap-client/src/types.ts
+++ b/packages/snap-client/src/types.ts
@@ -11,7 +11,7 @@ export type HTTPHeaders = { [key: string]: string };
 
 type RequesterConfig<T> = {
 	origin?: string;
-	alternateOrigin?: string;
+	secondaryOrigin?: string;
 	headers?: HTTPHeaders;
 	cache?: CacheConfig;
 	globals?: Partial<T>;

--- a/packages/snap-preact/src/Templates/SnapTemplates.tsx
+++ b/packages/snap-preact/src/Templates/SnapTemplates.tsx
@@ -379,6 +379,7 @@ export function createSnapConfig(templateConfig: SnapTemplatesConfig, templatesS
 				siteId: templateConfig.config?.siteId,
 			},
 			config: {
+				...(templateConfig.config?.client || {}),
 				initiator: `snap/templates/${version}`,
 			},
 		},

--- a/packages/snap-preact/src/Templates/Stores/TemplateStore.ts
+++ b/packages/snap-preact/src/Templates/Stores/TemplateStore.ts
@@ -34,6 +34,7 @@ import type {
 	ThemeVariablesPartial,
 } from '../../../components/src';
 import type { GlobalThemeStyleScript, IntegrationPlatforms } from '../../types';
+import type { ClientConfig } from '@searchspring/snap-client';
 
 export type TemplateThemeTypes = 'library' | 'local';
 export type TemplateTypes = 'search' | 'autocomplete' | `recommendation/${RecsTemplateTypes}`;
@@ -117,6 +118,7 @@ export type TemplateStoreConfigConfig = {
 		currency?: CurrencyCodes;
 		language?: LanguageCodes;
 		platform?: IntegrationPlatforms;
+		client?: ClientConfig;
 	};
 	plugins?: PluginsConfigs;
 	translations?: {


### PR DESCRIPTION
This adds the ability (temporarily) to set the client config to allow setting "origin" for hitting alternative API domains (eg. Athos platform). Once URLs solidify we may simply switch to a `platform` or `region` in the config to switch the client configuration under the hood, but for now we need some fine grained control.

Example usage:

```
const siteId = 'abc123';

let config: SnapTemplatesConfig = {
	config: {
		siteId,
		language: 'en',
		currency: 'usd',
		platform: 'other',
		client: {
			meta: {
				origin: `https://${siteId}.a.athoscommerce.io`,
			},
			search: {
				origin: `https://${siteId}.a.athoscommerce.io`,
			},
			autocomplete: {
				origin: `https://${siteId}.a.athoscommerce.io`,
			},
			suggest: {
				origin: `https://${siteId}.a.athoscommerce.io`,
			},
			recommend: {
				origin: `https://${siteId}.a.athoscommerce.io`,
			},
		},
	},
	
	...
```