### PR TITLE
fix(searchresponse.ts): need to stringify propertys before we unescap…

### DIFF
--- a/packages/snap-client/src/Client/transforms/searchResponse.ts
+++ b/packages/snap-client/src/Client/transforms/searchResponse.ts
@@ -471,6 +471,6 @@ function decodeProperty(encoded: string | string[] | SearchResponseModelResultBa
 			return item;
 		});
 	} else {
-		return unescapeHTML(String(encoded));
+		return unescapeHTML(String(JSON.stringify(encoded)));
 	}
 }


### PR DESCRIPTION
…eHTML them to ensure we dont end up with [object,object] attributes