### PR TITLE
Update API endpoint from io to net

### DIFF
--- a/packages/snap-client/src/Client/apis/Recommend.test.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.test.ts
@@ -75,7 +75,7 @@ describe('Recommend Api', () => {
 			],
 		};
 
-		const requestUrl = 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend';
+		const requestUrl = 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend';
 
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
@@ -99,7 +99,7 @@ describe('Recommend Api', () => {
 			body: `{"profiles":[{"tag":"similar"}],"siteId":"8uyt2m","${NO_BEACON_PARAM}":true}`,
 		};
 
-		const requestUrl = 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend';
+		const requestUrl = 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend';
 
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
@@ -139,7 +139,7 @@ describe('Recommend Api', () => {
 		product: 'marnie-runner-2-7x10',
 	};
 
-	const RequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend';
+	const RequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend';
 
 	it('batchRecommendations batches as expected', async () => {
 		const api = new RecommendAPI(new ApiConfiguration(apiConfig));
@@ -344,8 +344,8 @@ describe('Recommend Api', () => {
 		};
 
 		expect(requestMock).toHaveBeenCalledTimes(2);
-		expect(requestMock).toHaveBeenNthCalledWith(1, 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend', firstBatchPOSTParams);
-		expect(requestMock).toHaveBeenNthCalledWith(2, 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend', secondBatchPOSTParams);
+		expect(requestMock).toHaveBeenNthCalledWith(1, 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend', firstBatchPOSTParams);
+		expect(requestMock).toHaveBeenNthCalledWith(2, 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend', secondBatchPOSTParams);
 		requestMock.mockReset();
 	});
 
@@ -436,8 +436,8 @@ describe('Recommend Api', () => {
 		};
 
 		expect(requestMock).toHaveBeenCalledTimes(2);
-		expect(requestMock).toHaveBeenNthCalledWith(1, 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend', POSTParams8uyt2m);
-		expect(requestMock).toHaveBeenNthCalledWith(2, 'https://123abc.a.p13n.athoscommerce.io/v1/recommend', POSTParams123abc);
+		expect(requestMock).toHaveBeenNthCalledWith(1, 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend', POSTParams8uyt2m);
+		expect(requestMock).toHaveBeenNthCalledWith(2, 'https://123abc.a.p13n.athoscommerce.net/v1/recommend', POSTParams123abc);
 		requestMock.mockReset();
 	});
 
@@ -707,7 +707,7 @@ describe('Recommend Api', () => {
 			}),
 		};
 
-		const POSTRequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend';
+		const POSTRequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend';
 
 		const POSTRequestMock = jest
 			.spyOn(global.window, 'fetch')
@@ -830,7 +830,7 @@ describe('Recommend Api', () => {
 			}),
 		};
 
-		const POSTRequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend';
+		const POSTRequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend';
 
 		const POSTRequestMock = jest
 			.spyOn(global.window, 'fetch')
@@ -911,7 +911,7 @@ describe('Recommend Api', () => {
 			}),
 		};
 
-		const POSTRequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.io/v1/recommend';
+		const POSTRequestUrl = 'https://8uyt2m.a.p13n.athoscommerce.net/v1/recommend';
 
 		const POSTRequestMock = jest
 			.spyOn(global.window, 'fetch')


### PR DESCRIPTION
As part of GA, personalization API urls should be `.net` instead of `.io`. If this is already on someone's radar, feel free to close this 👍 