### PR TITLE
Support for withRecInfo

### DIFF
--- a/packages/snap-client/src/Client/apis/Recommend.test.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.test.ts
@@ -1016,4 +1016,59 @@ describe('Recommend Api', () => {
 		expect(POSTRequestMock).toHaveBeenCalledWith(POSTRequestUrl, POSTParams);
 		POSTRequestMock.mockReset();
 	});
+
+	it('batchRecommendations forwards withRecInfo when set on the request', async () => {
+		const api = new RecommendAPI(new ApiConfiguration(apiConfig));
+
+		const requestMock = jest
+			.spyOn(global.window, 'fetch')
+			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve([mockData.recommend()]) } as Response));
+
+		api.batchRecommendations({
+			tag: 'similar',
+			siteId: '8uyt2m',
+			withRecInfo: true,
+		});
+
+		await wait(250);
+
+		const POSTParams = {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'text/plain',
+			},
+			body: `{"profiles":[{"tag":"similar"}],"siteId":"8uyt2m","withRecInfo":true}`,
+		};
+
+		expect(requestMock).toHaveBeenCalledWith(RequestUrl, POSTParams);
+		requestMock.mockReset();
+	});
+
+	it('batchRecommendations does not include withRecInfo in POST body when not set', async () => {
+		const api = new RecommendAPI(new ApiConfiguration(apiConfig));
+
+		const requestMock = jest
+			.spyOn(global.window, 'fetch')
+			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve([mockData.recommend()]) } as Response));
+
+		api.batchRecommendations({
+			tag: 'similar',
+			siteId: '8uyt2m',
+		});
+
+		await wait(250);
+
+		const POSTParams = {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'text/plain',
+			},
+			body: `{"profiles":[{"tag":"similar"}],"siteId":"8uyt2m"}`,
+		};
+
+		expect(requestMock).toHaveBeenCalledWith(RequestUrl, POSTParams);
+		const body = JSON.parse(requestMock.mock.calls[0][1]!.body as string);
+		expect(body).not.toHaveProperty('withRecInfo');
+		requestMock.mockReset();
+	});
 });

--- a/packages/snap-client/src/Client/apis/Recommend.test.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.test.ts
@@ -1071,4 +1071,41 @@ describe('Recommend Api', () => {
 		expect(body).not.toHaveProperty('withRecInfo');
 		requestMock.mockReset();
 	});
+
+	it('batchRecommendations enables withRecInfo for whole batch if any request sets it to true', async () => {
+		const api = new RecommendAPI(new ApiConfiguration(apiConfig));
+
+		const requestMock = jest
+			.spyOn(global.window, 'fetch')
+			.mockImplementation(() =>
+				Promise.resolve({ status: 200, json: () => Promise.resolve([mockData.recommend(), mockData.recommend()]) } as Response)
+			);
+
+		// only one of the two batched requests sets withRecInfo
+		api.batchRecommendations({
+			tag: 'similar',
+			siteId: '8uyt2m',
+			batched: true,
+			withRecInfo: true,
+		});
+
+		api.batchRecommendations({
+			tag: 'crossSell',
+			siteId: '8uyt2m',
+			batched: true,
+		});
+
+		await wait(250);
+
+		const POSTParams = {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'text/plain',
+			},
+			body: `{"profiles":[{"tag":"similar"},{"tag":"crossSell"}],"siteId":"8uyt2m","withRecInfo":true}`,
+		};
+
+		expect(requestMock).toHaveBeenCalledWith(RequestUrl, POSTParams);
+		requestMock.mockReset();
+	});
 });

--- a/packages/snap-client/src/Client/apis/Recommend.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.ts
@@ -130,6 +130,9 @@ export class RecommendAPI extends API<RecommendRequesterPaths> {
 					new Set((batch.request.filters || []).concat(transformRecommendationFiltersPost(filters) || []).map((filter) => JSON.stringify(filter)))
 				).map((stringyFilter) => JSON.parse(stringyFilter));
 
+				// withRecInfo is enabled if any batched request sets it to true
+				const mergedWithRecInfo = batch.request.withRecInfo || withRecInfo || undefined;
+
 				batch.request = {
 					...batch.request,
 					...defined({
@@ -141,7 +144,7 @@ export class RecommendAPI extends API<RecommendRequesterPaths> {
 						cart,
 						lastViewed,
 						shopper,
-						withRecInfo,
+						withRecInfo: mergedWithRecInfo,
 					}),
 				};
 				if (this.configuration.mode == AppMode.development) {

--- a/packages/snap-client/src/Client/apis/Recommend.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.ts
@@ -121,7 +121,7 @@ export class RecommendAPI extends API<RecommendRequesterPaths> {
 				}
 
 				// parameters used globally
-				const { products, blockedItems, filters, test, cart, lastViewed, shopper } = entry.request;
+				const { products, blockedItems, filters, test, cart, lastViewed, shopper, withRecInfo } = entry.request;
 
 				// merge and de-dupe global array fields
 				const dedupedProducts = Array.from(new Set((batch.request.products || []).concat(products || [])));
@@ -141,6 +141,7 @@ export class RecommendAPI extends API<RecommendRequesterPaths> {
 						cart,
 						lastViewed,
 						shopper,
+						withRecInfo,
 					}),
 				};
 				if (this.configuration.mode == AppMode.development) {

--- a/packages/snap-client/src/types.ts
+++ b/packages/snap-client/src/types.ts
@@ -128,6 +128,7 @@ export type RecommendRequestGlobalsModel = {
 	blockedItems?: string[];
 	batchId?: number;
 	test?: boolean;
+	withRecInfo?: boolean;
 };
 
 export type RecommendRequestOptionsModel = {


### PR DESCRIPTION
Can test with this plugin:
```
const filterRecommendations = (controller) => {
	controller.on('beforeSearch', ({ request }, next) => {
		request.withRecInfo = true;
		next();
	});

	controller.on('afterSearch', ({ response }, next) => {
		response.results = response.results.filter((result) => result?.recInfo?.recType === 'CrossSellManual');
		next();
	});
}
```