### PR TITLE
LayoutSelector - pike - hardcoded ccp bugfix

### DIFF
--- a/packages/snap-preact/components/src/themes/pike/components/molecules/layoutSelector.ts
+++ b/packages/snap-preact/components/src/themes/pike/components/molecules/layoutSelector.ts
@@ -69,12 +69,5 @@ export const layoutSelector: ThemeComponent<'layoutSelector', LayoutSelectorProp
 		'layoutSelector select': {
 			hideSelection: false,
 		},
-		'layoutSelector list': {
-			hideTitleText: true,
-			hideOptionLabels: true,
-		},
-		'layoutSelector radioList': {
-			hideTitleText: true,
-		},
 	},
 };


### PR DESCRIPTION
fix(layoutselector-pike): removing hardcoded ccp prop values that block usage of props. 

If a user wants to show labels and titles on pike they should be allowed to do so, we have props on this component to hide them, and they are optional in the layoutOptions. hardcoding those ccp props for list and radioList bypass the props on layoutselector making them useless and confusing when switching layout types 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215222998357429