### PR TITLE
templates globals and action settings

### DIFF
--- a/docs/TEMPLATES_CONFIG.md
+++ b/docs/TEMPLATES_CONFIG.md
@@ -249,6 +249,7 @@ In addition to the common target properties, the following properties apply to t
 | Configuration Option | Description | Type | Default |
 |----------------------|-------------|------|---------|
 | `search` | Search configuration | Object | ➖ |
+| `search.globals` | Search request globals | Object | ➖ |
 | `search.plugins` | Search specific plugins configurations | Object | ➖ |
 | `search.targets` | Search target configurations | Array | Required |
 | `search.targets[].selector` | CSS selector for search target | String | Required |
@@ -266,6 +267,8 @@ In addition to the common target properties, the following properties apply to t
 | Configuration Option | Description | Type | Default |
 |----------------------|-------------|------|---------|
 | `autocomplete` | Autocomplete configuration | Object | ➖ |
+| `autocomplete.action` | URL to navigate to on form submission (required if input is not inside a `<form>`) | String | ➖ |
+| `autocomplete.globals` | Autocomplete request globals | Object | ➖ |
 | `autocomplete.plugins` | Autocomplete specific plugins configurations | Object | ➖ |
 | `autocomplete.targets` | Autocomplete target configurations | Array | Required |
 | `autocomplete.targets[].inputSelector` | DOM selector for the autocomplete `<input>` element | String | Required |

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -865,7 +865,12 @@ describe('Autocomplete Controller', () => {
 
 		await controller.bind();
 
-		expect(warnFn).toHaveBeenCalledWith(expect.stringContaining("no 'action' URL is configured"));
+		expect(warnFn).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Missing form action url! Input element is not inside a <form> and no 'action' URL is configured. Enter key will not submit. Set the 'action' url in the config to enable submission."
+			),
+			expect.any(HTMLInputElement)
+		);
 
 		warnFn.mockClear();
 	});

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -848,6 +848,28 @@ describe('Autocomplete Controller', () => {
 		beforeSubmitfn.mockClear();
 	});
 
+	it('logs a warning when input is outside a form and no action is configured', async () => {
+		document.body.innerHTML = '<div><input type="text" id="search_query"></div>';
+
+		const controller = new AutocompleteController(acConfig, {
+			client: new MockClient(globals, {}),
+			store: new AutocompleteStore(acConfig, services),
+			urlManager,
+			eventManager: new EventManager(),
+			profiler: new Profiler(),
+			logger: new Logger(),
+			tracker: new Tracker(globals),
+		});
+
+		const warnFn = jest.spyOn(controller.log, 'warn');
+
+		await controller.bind();
+
+		expect(warnFn).toHaveBeenCalledWith(expect.stringContaining("no 'action' URL is configured"));
+
+		warnFn.mockClear();
+	});
+
 	it('adds fallback query', async () => {
 		document.body.innerHTML = '<div><form action="/search.html"><input type="text" id="search_query"></form></div>';
 		const controller = new AutocompleteController(acConfig, {

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -751,7 +751,7 @@ export class AutocompleteController extends AbstractController {
 					// set parameters as globals
 					this.store.setService('urlManager', this.urlManager.reset().withGlobals(formParameters));
 				}
-			} else {
+			} else if (this.config.settings?.bind?.submit) {
 				this.log.warn(
 					`Missing form action url! Input element "${this.config.selector}" is not inside a <form> and no 'action' URL is configured. Enter key will not submit. Set the 'action' url in the config to enable submission.`
 				);

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -751,6 +751,10 @@ export class AutocompleteController extends AbstractController {
 					// set parameters as globals
 					this.store.setService('urlManager', this.urlManager.reset().withGlobals(formParameters));
 				}
+			} else {
+				this.log.warn(
+					`Missing form action url! Input element "${this.config.selector}" is not inside a <form> and no 'action' URL is configured. Enter key will not submit. Set the 'action' url in the config to enable submission.`
+				);
 			}
 
 			// set the root URL on urlManager

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -753,7 +753,8 @@ export class AutocompleteController extends AbstractController {
 				}
 			} else if (this.config.settings?.bind?.submit) {
 				this.log.warn(
-					`Missing form action url! Input element "${this.config.selector}" is not inside a <form> and no 'action' URL is configured. Enter key will not submit. Set the 'action' url in the config to enable submission.`
+					`Missing form action url! Input element is not inside a <form> and no 'action' URL is configured. Enter key will not submit. Set the 'action' url in the config to enable submission.`,
+					input
 				);
 			}
 

--- a/packages/snap-preact/src/Templates/SnapTemplates.tsx
+++ b/packages/snap-preact/src/Templates/SnapTemplates.tsx
@@ -383,6 +383,7 @@ export function createSnapConfig(templateConfig: SnapTemplatesConfig | SnapTempl
 			config: {
 				id: 'search',
 				plugins: createPlugins(templateConfig, templatesStore, 'search'),
+				globals: templateConfig.search.globals || {},
 				settings: templateConfig.search.settings || {},
 			},
 			targeters: createSearchTargeters(templateConfig, templatesStore),
@@ -410,6 +411,8 @@ export function createSnapConfig(templateConfig: SnapTemplatesConfig | SnapTempl
 				id: 'autocomplete',
 				plugins: createPlugins(templateConfig, templatesStore, 'autocomplete'),
 				selector: templateConfig.autocomplete.targets.map((target) => target.inputSelector).join(', '),
+				action: templateConfig.autocomplete.action || '',
+				globals: templateConfig.autocomplete.globals || {},
 				settings: autocompleteControllerSettings,
 			},
 			targeters: createAutocompleteTargeters(templateConfig, templatesStore),

--- a/packages/snap-preact/src/Templates/Stores/TemplateStore.ts
+++ b/packages/snap-preact/src/Templates/Stores/TemplateStore.ts
@@ -1,6 +1,11 @@
 import type { h } from 'preact';
 import { observable, makeObservable } from 'mobx';
-import { type SearchStoreConfigSettings, type AutocompleteStoreConfigSettings } from '@athoscommerce/snap-store-mobx';
+import {
+	type SearchStoreConfigSettings,
+	type SearchStoreConfig,
+	type AutocompleteStoreConfigSettings,
+	type AutocompleteStoreConfig,
+} from '@athoscommerce/snap-store-mobx';
 import { StorageStore, StorageType } from '@athoscommerce/snap-toolbox';
 import { ThemeStore, ThemeStoreThemeConfig } from './ThemeStore';
 import { TargetStore } from './TargetStore';
@@ -369,11 +374,14 @@ export type TemplatesStoreConfigLocked = {
 	theme: TemplatesStoreThemeConfigLocked;
 	search?: {
 		targets: SearchTargetConfig[];
+		globals?: SearchStoreConfig['globals'];
 		settings?: SearchStoreConfigSettings;
 		plugins?: PluginsConfigsLocked;
 	};
 	autocomplete?: {
 		targets: AutocompleteTargetConfig[];
+		action?: string;
+		globals?: AutocompleteStoreConfig['globals'];
 		settings?: AutocompleteStoreConfigSettings;
 		plugins?: PluginsConfigsLocked;
 	};


### PR DESCRIPTION
feat(snaptemplates): adding spots in the config for you to pass controller config settings and globals

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215301569635762
  - https://app.asana.com/0/0/1215301639251467