### PR TITLE
numeric component names

### DIFF
--- a/packages/snap-preact/components/src/utilities/mergeProps.test.ts
+++ b/packages/snap-preact/components/src/utilities/mergeProps.test.ts
@@ -450,6 +450,29 @@ describe('mergeProps function with theme type', () => {
 			treePath: `button ${componentType}.first-button`,
 		});
 	});
+
+	it('nested treePath and numeric named component', () => {
+		const componentType = 'select';
+		const globalTheme = {
+			type: 'templates',
+			name: GLOBAL_THEME_NAME,
+		};
+
+		const defaultProps: Partial<SelectProps> = {};
+		const properties: Partial<SelectProps> = {
+			treePath: 'button',
+			name: '1',
+		};
+		const props = mergeProps(componentType, globalTheme, defaultProps, properties);
+		expect(props).toStrictEqual({
+			...defaultProps,
+			...properties,
+			theme: {
+				name: globalTheme.name,
+			},
+			treePath: `button ${componentType}.1`,
+		});
+	});
 });
 describe('sortSelectors function', () => {
 	it('orders strings by spaces', () => {

--- a/packages/snap-preact/components/src/utilities/mergeProps.ts
+++ b/packages/snap-preact/components/src/utilities/mergeProps.ts
@@ -69,7 +69,7 @@ export function mergeProps<GenericComponentProps extends ComponentProps>(
 			...props,
 		};
 
-		treePath += componentName?.match(/^[A-Z,a-z,-]+$/) ? `.${componentName}` : '';
+		treePath += componentName?.match(/^[A-Za-z0-9-]+$/) ? `.${componentName}` : '';
 
 		// component props from the theme
 		// add globalTheme props for components with selector matches if they exist


### PR DESCRIPTION
add support for numeric component names and use in treepath and ccp

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215263583960947