### PR TITLE
useLayoutOptions bugfix

### DIFF
--- a/packages/snap-preact/components/src/components/Templates/Search/Search.tsx
+++ b/packages/snap-preact/components/src/components/Templates/Search/Search.tsx
@@ -89,10 +89,8 @@ export const Search = observer((properties: SearchProps) => {
 		classNamePrefix = `ss__${componentNameToClassName(props.alias)}`;
 	}
 
-	// handle selected layoutOptions
-	if (globalTheme?.name && props.layoutOptions) {
-		useLayoutOptions(props, globalTheme);
-	}
+	// handle selected layoutOptions - must always call to preserve hook order
+	useLayoutOptions(props, globalTheme);
 
 	const store = controller.store;
 

--- a/packages/snap-preact/components/src/hooks/useLayoutOptions.test.tsx
+++ b/packages/snap-preact/components/src/hooks/useLayoutOptions.test.tsx
@@ -225,4 +225,49 @@ describe('useLayoutOptions', () => {
 			expect(props.theme.components.results).toEqual({ columns: 4 });
 		});
 	});
+
+	/**
+	 * Preact/React tracks hooks by call order (positional, not named). If useLayoutOptions
+	 * skips its internal useState/useControllerStorage call when layoutOptions is absent,
+	 * all subsequent hooks in the parent component shift position on re-render. This corrupts
+	 * component state and can break sibling components sharing the same render queue.
+	 *
+	 * This was the root cause of recommendation carousels becoming unresponsive to screen
+	 * resizing when rendered alongside a search component that only defined layoutOptions
+	 * at certain breakpoints (e.g. mobile only).
+	 */
+	describe('hook ordering stability', () => {
+		it('calls useControllerStorage even when layoutOptions is empty (preserves hook order)', () => {
+			const props = makeProps({ layoutOptions: [] });
+			runHook(props, {}, undefined);
+			expect(mockUseControllerStorage).toHaveBeenCalledTimes(1);
+		});
+
+		it('calls useControllerStorage even when layoutOptions is undefined (preserves hook order)', () => {
+			const props = makeProps({ layoutOptions: undefined });
+			runHook(props, {}, undefined);
+			expect(mockUseControllerStorage).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not modify props.theme when layoutOptions is empty', () => {
+			const props = makeProps({ layoutOptions: [] });
+			const originalTheme = props.theme;
+			runHook(props, {}, undefined);
+			expect(props.theme).toBe(originalTheme);
+		});
+
+		it('hook call count is the same with and without layoutOptions (stable hook order across renders)', () => {
+			const propsWithOptions = makeProps();
+			runHook(propsWithOptions, {}, { value: 1, label: 'grid' });
+			const callCountWithOptions = mockUseControllerStorage.mock.calls.length;
+
+			jest.clearAllMocks();
+
+			const propsWithoutOptions = makeProps({ layoutOptions: [] });
+			runHook(propsWithoutOptions, {}, undefined);
+			const callCountWithoutOptions = mockUseControllerStorage.mock.calls.length;
+
+			expect(callCountWithOptions).toBe(callCountWithoutOptions);
+		});
+	});
 });

--- a/packages/snap-preact/components/src/hooks/useLayoutOptions.tsx
+++ b/packages/snap-preact/components/src/hooks/useLayoutOptions.tsx
@@ -2,9 +2,10 @@ import deepmerge from 'deepmerge';
 import { useControllerStorage } from './useControllerStorage';
 import { Theme } from '../providers';
 import { ToolbarProps } from '../components/Organisms/Toolbar';
+import { LayoutSelectorOptions } from '../types';
 
 export const useLayoutOptions = (props: any, globalTheme: Theme) => {
-	const layoutOptions = props?.layoutOptions || [];
+	const layoutOptions: LayoutSelectorOptions = props?.layoutOptions || [];
 
 	// Note: only store serializable identifiers (value/label) to avoid JSON.stringify failures
 	// on option objects that may contain JSX (e.g. icon: { children: <span>...</span> })
@@ -20,11 +21,17 @@ export const useLayoutOptions = (props: any, globalTheme: Theme) => {
 	const toStorable = (option: any) => (option ? { value: option.value, label: option.label } : option);
 
 	// handle layoutOptions and selected option — store only serializable identifiers
+	// Always call useControllerStorage to preserve hook order across renders
 	const [storedSelection, setStoredSelection] = useControllerStorage(
 		props.controller,
 		'layoutOptions',
 		toStorable(layoutOptions.filter((option: any) => option.default).pop())
 	);
+
+	// Early return if no layoutOptions - hooks have already been called above
+	if (!layoutOptions.length) {
+		return;
+	}
 
 	// Resolve the stored identifier back to the full option object (which may contain JSX)
 	const selectedLayout = layoutOptions.find((option: any) => isSameOption(option, storedSelection));


### PR DESCRIPTION
bugfix for useLayoutOptions only being called on certain breakpoints, and removing the hook on others breaking hook order


**Issue**: The useLayoutOptions hook (which internally calls useState) was being called conditionally in the Search component — only when props.layoutOptions was defined. In configurations where layoutOptions only exists at certain breakpoints (e.g. only on mobile), resizing the window would add or remove a hook call mid-lifecycle. Preact tracks hooks by call order, so this shifted all subsequent hooks out of position, corrupting component state. This corrupted state disrupted Preact's render queue, which prevented sibling components (like Recommendations) from re-rendering when the theme's active breakpoint changed — making the recommendation carousel unresponsive to screen resizing.

**Fix**: Moved the useControllerStorage call (the hook) to always execute unconditionally at the top of useLayoutOptions, then added an early return for the no-op case. Removed the conditional guard around the useLayoutOptions call in Search.tsx. This ensures stable hook ordering across all renders regardless of which breakpoint is active.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215301569635750