### PR TITLE
Templates Button component children vs content props

### DIFF
--- a/packages/snap-preact/components/src/components/Atoms/Button/Button.stories.tsx
+++ b/packages/snap-preact/components/src/components/Atoms/Button/Button.stories.tsx
@@ -36,7 +36,6 @@ export default {
 				type: {
 					summary: 'string, JSX',
 				},
-				category: 'Templates Legal',
 			},
 			control: { type: 'text' },
 		},

--- a/packages/snap-preact/components/src/components/Atoms/Button/Button.tsx
+++ b/packages/snap-preact/components/src/components/Atoms/Button/Button.tsx
@@ -153,6 +153,7 @@ interface ButtonSubProps {
 export type ButtonProps = {
 	lang?: Partial<ButtonLang>;
 	name?: ButtonNames;
+	content?: string | JSX.Element;
 } & ButtonTemplatesLegalProps &
 	ComponentProps<ButtonProps>;
 
@@ -161,7 +162,6 @@ export type ButtonTemplatesLegalProps = {
 	borderColor?: string;
 	color?: string;
 	icon?: IconType | Partial<IconProps> | boolean;
-	content?: string | JSX.Element;
 	children?: ComponentChildren;
 	disabled?: boolean;
 	native?: boolean;

--- a/packages/snap-preact/components/src/components/Atoms/Button/Button.tsx
+++ b/packages/snap-preact/components/src/components/Atoms/Button/Button.tsx
@@ -121,7 +121,10 @@ export const Button = observer((properties: ButtonProps) => {
 	const langs = deepmerge(defaultLang, lang || {});
 	const mergedLang = useLang(langs as any, {});
 
-	return content || children || icon || lang?.button?.value ? (
+	// @ts-ignore - additionalProps may contain dangerouslySetInnerHTML which is fine to spread on the element, but doesn't fit the ButtonProps type definition so we need to ignore it here.
+	const hasDangerouslySetInnerHTML = Boolean(additionalProps.dangerouslySetInnerHTML);
+
+	return content || children || icon || lang?.button?.value || hasDangerouslySetInnerHTML ? (
 		<CacheProvider>
 			{native ? (
 				<button {...elementProps}>

--- a/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
@@ -326,9 +326,7 @@ export const Result = observer((properties: ResultProps) => {
 
 					{!hideAddToCartButton && (
 						<div className="ss__result__add-to-cart-wrapper">
-							<Button {...subProps.button} {...mergedLang.addToCartButtonText.attributes}>
-								<span {...mergedLang.addToCartButtonText.value}></span>
-							</Button>
+							<Button {...subProps.button} {...mergedLang.addToCartButtonText.all} />
 						</div>
 					)}
 				</div>

--- a/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
@@ -326,7 +326,9 @@ export const Result = observer((properties: ResultProps) => {
 
 					{!hideAddToCartButton && (
 						<div className="ss__result__add-to-cart-wrapper">
-							<Button {...subProps.button} children={addToCartButtonText} {...mergedLang.addToCartButtonText.all} />
+							<Button {...subProps.button} {...mergedLang.addToCartButtonText.attributes}>
+								<span {...mergedLang.addToCartButtonText.value}></span>
+							</Button>
 						</div>
 					)}
 				</div>

--- a/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
+++ b/packages/snap-preact/components/src/components/Molecules/Result/Result.tsx
@@ -326,7 +326,7 @@ export const Result = observer((properties: ResultProps) => {
 
 					{!hideAddToCartButton && (
 						<div className="ss__result__add-to-cart-wrapper">
-							<Button {...subProps.button} content={addToCartButtonText} {...mergedLang.addToCartButtonText.all} />
+							<Button {...subProps.button} children={addToCartButtonText} {...mergedLang.addToCartButtonText.all} />
 						</div>
 					)}
 				</div>


### PR DESCRIPTION
refactor(button): making content prop templates illegal and all internal usage now uses children prop

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215223311984012