### PR TITLE
Test Adjust

### DIFF
--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/autocomplete/autocomplete.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/autocomplete/autocomplete.cy.js
@@ -85,13 +85,19 @@ describe('Autocomplete', () => {
 			});
 
 			cy.visit(config.url);
+			cy.addLocalSnap();
+			cy.waitForBundle();
 
 			cy.snapController('autocomplete').then(({ store }) => {
 				if (config.selectors.website.openInputButton) {
-					cy.get(config.selectors.website.openInputButton).first().click({ force: true });
+					cy.get('body').then(($body) => {
+						if ($body.find(config.selectors.website.openInputButton).length) {
+							cy.get(config.selectors.website.openInputButton).first().click({ force: true });
+						}
+					});
 				}
 
-				cy.get(config.selectors.website.input).first().should('exist').click().focus();
+				cy.get(config.selectors.website.input, { timeout: 20000 }).first().should('exist').click({ force: true }).focus();
 
 				// TODO: remove - but is currently needed for cases where we are getting no trending terms back from the API
 				if (store.trending.length) {

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/autocomplete/autocomplete.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/autocomplete/autocomplete.cy.js
@@ -90,11 +90,7 @@ describe('Autocomplete', () => {
 
 			cy.snapController('autocomplete').then(({ store }) => {
 				if (config.selectors.website.openInputButton) {
-					cy.get('body').then(($body) => {
-						if ($body.find(config.selectors.website.openInputButton).length) {
-							cy.get(config.selectors.website.openInputButton).first().click({ force: true });
-						}
-					});
+					cy.get(config.selectors.website.openInputButton, { timeout: 20000 }).first().click({ force: true });
 				}
 
 				cy.get(config.selectors.website.input, { timeout: 20000 }).first().should('exist').click({ force: true }).focus();

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendation/recommendation.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendation/recommendation.cy.js
@@ -184,8 +184,9 @@ describe('Recommendations', () => {
 					cy.get(integration?.selectors?.recommendation.activeSlide).should('exist');
 					cy.get(`${integration?.selectors?.recommendation.activeSlide} ${integration?.selectors?.recommendation.result} a`)
 						.first()
-						.should('have.attr', 'href')
+						.invoke('attr', 'href')
 						.then((url) => {
+							expect(url).to.be.a('string').and.not.be.empty;
 							cy.get(`${integration?.selectors?.recommendation.activeSlide} ${integration?.selectors?.recommendation.result} a`)
 								.first()
 								.click({ force: true })

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendation/recommendation.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendation/recommendation.cy.js
@@ -181,18 +181,18 @@ describe('Recommendations', () => {
 				});
 
 				it('can click on a result and go to that page', function () {
-					cy.document().then((doc) => {
-						cy.snapController(integration?.selectors?.recommendation.controller).then(({ store }) => {
-							cy.get(integration?.selectors?.recommendation.activeSlide).should('exist');
-							let url = doc.querySelector(`${integration?.selectors?.recommendation.activeSlide} ${integration?.selectors?.recommendation.result} a`)
-								.attributes?.href?.value;
-							cy.get(integration?.selectors?.recommendation.activeSlide)
-								.click({ multiple: true })
+					cy.get(integration?.selectors?.recommendation.activeSlide).should('exist');
+					cy.get(`${integration?.selectors?.recommendation.activeSlide} ${integration?.selectors?.recommendation.result} a`)
+						.first()
+						.should('have.attr', 'href')
+						.then((url) => {
+							cy.get(`${integration?.selectors?.recommendation.activeSlide} ${integration?.selectors?.recommendation.result} a`)
+								.first()
+								.click({ force: true })
 								.then(() => {
 									cy.location('href').should('include', url);
 								});
 						});
-					});
 				});
 
 				describe('Tests Custom Result Component', () => {

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundle/recommendationBundle.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundle/recommendationBundle.cy.js
@@ -212,8 +212,9 @@ describe('BundledRecommendations', () => {
 			cy.get(config?.selectors?.recommendation.activeSlide).should('exist');
 			cy.get(`${config?.selectors?.recommendation.activeSlide} ${config?.selectors?.recommendation.result} a`)
 				.first()
-				.should('have.attr', 'href')
+				.invoke('attr', 'href')
 				.then((url) => {
+					expect(url).to.be.a('string').and.not.be.empty;
 					cy.get(`${config?.selectors?.recommendation.activeSlide} ${config?.selectors?.recommendation.result} a`)
 						.first()
 						.click({ force: true })

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundle/recommendationBundle.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundle/recommendationBundle.cy.js
@@ -209,19 +209,18 @@ describe('BundledRecommendations', () => {
 		});
 
 		it('can click on a result and go to that page', function () {
-			cy.document().then((doc) => {
-				cy.snapController(config?.selectors?.recommendation.controller).then(({ store }) => {
-					cy.get(config?.selectors?.recommendation.activeSlide).should('exist');
-					let url = doc.querySelector(`${config?.selectors?.recommendation.activeSlide} ${config?.selectors?.recommendation.result} a`).attributes
-						?.href?.value;
-					cy.get(`${config?.selectors?.recommendation.activeSlide} a`)
+			cy.get(config?.selectors?.recommendation.activeSlide).should('exist');
+			cy.get(`${config?.selectors?.recommendation.activeSlide} ${config?.selectors?.recommendation.result} a`)
+				.first()
+				.should('have.attr', 'href')
+				.then((url) => {
+					cy.get(`${config?.selectors?.recommendation.activeSlide} ${config?.selectors?.recommendation.result} a`)
 						.first()
 						.click({ force: true })
 						.then(() => {
 							cy.location('href').should('include', url);
 						});
 				});
-			});
 		});
 
 		describe('Tests Custom Result Component', () => {

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleEasyAdd/recommendationBundleEasyAdd.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleEasyAdd/recommendationBundleEasyAdd.cy.js
@@ -116,18 +116,18 @@ describe('BundledRecommendations', () => {
 		});
 
 		it('can click on a result and go to that page', function () {
-			cy.document().then((doc) => {
-				cy.snapController(config?.selectors?.recommendation.controller).then(({ store }) => {
-					cy.get(config?.selectors?.recommendation.result).should('exist');
-					let url = doc.querySelector(`${config?.selectors?.recommendation.result} a`).attributes?.href?.value;
+			cy.get(config?.selectors?.recommendation.result).should('exist');
+			cy.get(`${config?.selectors?.recommendation.result} a`)
+				.first()
+				.should('have.attr', 'href')
+				.then((url) => {
 					cy.get(`${config?.selectors?.recommendation.result} a`)
 						.first()
-						.click({ multiple: true })
+						.click({ force: true })
 						.then(() => {
 							cy.location('href').should('include', url);
 						});
 				});
-			});
 		});
 
 		describe('Tests Custom Result Component', () => {

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleEasyAdd/recommendationBundleEasyAdd.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleEasyAdd/recommendationBundleEasyAdd.cy.js
@@ -119,8 +119,9 @@ describe('BundledRecommendations', () => {
 			cy.get(config?.selectors?.recommendation.result).should('exist');
 			cy.get(`${config?.selectors?.recommendation.result} a`)
 				.first()
-				.should('have.attr', 'href')
+				.invoke('attr', 'href')
 				.then((url) => {
+					expect(url).to.be.a('string').and.not.be.empty;
 					cy.get(`${config?.selectors?.recommendation.result} a`)
 						.first()
 						.click({ force: true })

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleList/recommendationBundleList.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleList/recommendationBundleList.cy.js
@@ -152,10 +152,11 @@ describe('BundledRecommendations', () => {
 		});
 
 		it('can click on a result and go to that page', function () {
-			cy.document().then((doc) => {
-				cy.snapController(config?.selectors?.recommendation.controller).then(({ store }) => {
-					cy.get(config?.selectors?.recommendation.result).should('exist');
-					let url = doc.querySelector(`${config?.selectors?.recommendation.result} a`).attributes?.href?.value;
+			cy.get(config?.selectors?.recommendation.result).should('exist');
+			cy.get(`${config?.selectors?.recommendation.result} a`)
+				.first()
+				.should('have.attr', 'href')
+				.then((url) => {
 					cy.get(`${config?.selectors?.recommendation.result} a`)
 						.first()
 						.click({ force: true })
@@ -163,7 +164,6 @@ describe('BundledRecommendations', () => {
 							cy.location('href').should('include', url);
 						});
 				});
-			});
 		});
 
 		describe('Tests Custom Result Component', () => {

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleList/recommendationBundleList.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleList/recommendationBundleList.cy.js
@@ -155,8 +155,9 @@ describe('BundledRecommendations', () => {
 			cy.get(config?.selectors?.recommendation.result).should('exist');
 			cy.get(`${config?.selectors?.recommendation.result} a`)
 				.first()
-				.should('have.attr', 'href')
+				.invoke('attr', 'href')
 				.then((url) => {
+					expect(url).to.be.a('string').and.not.be.empty;
 					cy.get(`${config?.selectors?.recommendation.result} a`)
 						.first()
 						.click({ force: true })

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleVertical/recommendationBundleVertical.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleVertical/recommendationBundleVertical.cy.js
@@ -147,8 +147,9 @@ describe('BundledRecommendations', () => {
 			cy.get(config?.selectors?.recommendation.result).should('exist');
 			cy.get(`${config?.selectors?.recommendation.result} a`)
 				.first()
-				.should('have.attr', 'href')
+				.invoke('attr', 'href')
 				.then((url) => {
+					expect(url).to.be.a('string').and.not.be.empty;
 					cy.get(`${config?.selectors?.recommendation.result} a`)
 						.first()
 						.click({ force: true })

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleVertical/recommendationBundleVertical.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/recommendationBundleVertical/recommendationBundleVertical.cy.js
@@ -144,18 +144,18 @@ describe('BundledRecommendations', () => {
 		});
 
 		it('can click on a result and go to that page', function () {
-			cy.document().then((doc) => {
-				cy.snapController(config?.selectors?.recommendation.controller).then(({ store }) => {
-					cy.get(config?.selectors?.recommendation.result).should('exist');
-					let url = doc.querySelector(`${config?.selectors?.recommendation.result} a`).attributes?.href?.value;
+			cy.get(config?.selectors?.recommendation.result).should('exist');
+			cy.get(`${config?.selectors?.recommendation.result} a`)
+				.first()
+				.should('have.attr', 'href')
+				.then((url) => {
 					cy.get(`${config?.selectors?.recommendation.result} a`)
 						.first()
-						.click({ force: true, multiple: true })
+						.click({ force: true })
 						.then(() => {
 							cy.location('href').should('include', url);
 						});
 				});
-			});
 		});
 
 		describe('Tests Custom Result Component', () => {

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/search/customResult.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/search/customResult.cy.js
@@ -53,8 +53,9 @@ describe('Custom Result Compnent', () => {
 		cy.get(config?.selectors?.search.customResult).should('exist');
 		cy.get(`${config?.selectors?.search.customResult} a`)
 			.first()
-			.should('have.attr', 'href')
+			.invoke('attr', 'href')
 			.then((url) => {
+				expect(url).to.be.a('string').and.not.be.empty;
 				cy.get(`${config?.selectors?.search.customResult} a`)
 					.first()
 					.click()

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/search/customResult.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/search/customResult.cy.js
@@ -50,10 +50,11 @@ describe('Custom Result Compnent', () => {
 	});
 
 	it('can click on a result and go to that page', function () {
-		cy.document().then((doc) => {
-			cy.snapController().then(({ store }) => {
-				cy.get(config?.selectors?.search.customResult).should('exist');
-				let url = doc.querySelector(`${config?.selectors?.search.customResult} a`).attributes?.href?.value;
+		cy.get(config?.selectors?.search.customResult).should('exist');
+		cy.get(`${config?.selectors?.search.customResult} a`)
+			.first()
+			.should('have.attr', 'href')
+			.then((url) => {
 				cy.get(`${config?.selectors?.search.customResult} a`)
 					.first()
 					.click()
@@ -61,6 +62,5 @@ describe('Custom Result Compnent', () => {
 						cy.location('href').should('include', url);
 					});
 			});
-		});
 	});
 });

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/search/infinite.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/search/infinite.cy.js
@@ -28,7 +28,8 @@ describe('Infinite Setting Test', () => {
 			cy.get('.ss__result').should('have.length', resultsPerPage);
 
 			// click next page, results should be appended
-			cy.get('.ss__pagination__page--next, .ss__load-more__button').first().click({ force: true });
+			cy.get('.ss__pagination__page--next, .ss__load-more__button').should('exist').first().click({ force: true });
+			cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 2));
 			cy.snapController().then(({ store }) => {
 				expect(store.results.length).to.equal(resultsPerPage * 2);
 				expect(store.pagination.begin).to.equal(1);
@@ -37,6 +38,7 @@ describe('Infinite Setting Test', () => {
 
 			//refresh page, should not backfill
 			cy.reload().then(() => {
+				cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage));
 				cy.snapController().then(({ store }) => {
 					expect(store.results.length).to.equal(resultsPerPage);
 				});
@@ -66,7 +68,7 @@ describe('Infinite Setting Test', () => {
 			cy.get('.ss__result').should('have.length', resultsPerPage);
 
 			// click next page, results should be appended
-			cy.get('.ss__pagination__page--next, .ss__load-more__button').first().click({ force: true });
+			cy.get('.ss__pagination__page--next, .ss__load-more__button').should('exist').first().click({ force: true });
 			cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 2));
 			cy.snapController().then(({ store }) => {
 				expect(store.results.length).to.equal(resultsPerPage * 2);
@@ -75,14 +77,14 @@ describe('Infinite Setting Test', () => {
 
 			//refresh page, should backfill
 			cy.reload().then(() => {
+				cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 2));
 				cy.snapController().then(({ store }) => {
 					expect(store.results.length).to.equal(resultsPerPage * 2);
 				});
 			});
 
 			// click next page again, expect 3 pages of results
-			cy.get('.ss__pagination__page--next, .ss__load-more__button').first().click({ force: true });
-			cy.wait(100);
+			cy.get('.ss__pagination__page--next, .ss__load-more__button').should('exist').first().click({ force: true });
 			cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 3));
 			cy.snapController().then(({ store }) => {
 				expect(store.results.length).to.equal(resultsPerPage * 3);
@@ -91,6 +93,7 @@ describe('Infinite Setting Test', () => {
 
 			//refresh page, should NOT backfill again due to page > backfill and is at page 1
 			cy.reload().then(() => {
+				cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage));
 				cy.snapController().then(({ store }) => {
 					expect(store.results.length).to.equal(resultsPerPage);
 					expect(store.pagination.current.number).to.equal(1);

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/searchHorizontal/customResult.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/searchHorizontal/customResult.cy.js
@@ -53,8 +53,9 @@ describe('Custom Result Compnent', () => {
 		cy.get(config?.selectors?.search.customResult).should('exist');
 		cy.get(`${config?.selectors?.search.customResult} a`)
 			.first()
-			.should('have.attr', 'href')
+			.invoke('attr', 'href')
 			.then((url) => {
+				expect(url).to.be.a('string').and.not.be.empty;
 				cy.get(`${config?.selectors?.search.customResult} a`)
 					.first()
 					.click()

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/searchHorizontal/customResult.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/searchHorizontal/customResult.cy.js
@@ -50,10 +50,11 @@ describe('Custom Result Compnent', () => {
 	});
 
 	it('can click on a result and go to that page', function () {
-		cy.document().then((doc) => {
-			cy.snapController().then(({ store }) => {
-				cy.get(config?.selectors?.search.customResult).should('exist');
-				let url = doc.querySelector(`${config?.selectors?.search.customResult} a`).attributes?.href?.value;
+		cy.get(config?.selectors?.search.customResult).should('exist');
+		cy.get(`${config?.selectors?.search.customResult} a`)
+			.first()
+			.should('have.attr', 'href')
+			.then((url) => {
 				cy.get(`${config?.selectors?.search.customResult} a`)
 					.first()
 					.click()
@@ -61,6 +62,5 @@ describe('Custom Result Compnent', () => {
 						cy.location('href').should('include', url);
 					});
 			});
-		});
 	});
 });

--- a/packages/snap-preact-demo/tests/cypress/e2e/templates/searchHorizontal/infinite.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/templates/searchHorizontal/infinite.cy.js
@@ -28,7 +28,8 @@ describe('Infinite Setting Test', () => {
 			cy.get('.ss__result').should('have.length', resultsPerPage);
 
 			// click next page, results should be appended
-			cy.get('.ss__pagination__page--next, .ss__load-more__button').first().click({ force: true });
+			cy.get('.ss__pagination__page--next, .ss__load-more__button').should('exist').first().click({ force: true });
+			cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 2));
 			cy.snapController().then(({ store }) => {
 				expect(store.results.length).to.equal(resultsPerPage * 2);
 				expect(store.pagination.begin).to.equal(1);
@@ -37,6 +38,7 @@ describe('Infinite Setting Test', () => {
 
 			//refresh page, should not backfill
 			cy.reload().then(() => {
+				cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage));
 				cy.snapController().then(({ store }) => {
 					expect(store.results.length).to.equal(resultsPerPage);
 				});
@@ -66,7 +68,7 @@ describe('Infinite Setting Test', () => {
 			cy.get('.ss__result').should('have.length', resultsPerPage);
 
 			// click next page, results should be appended
-			cy.get('.ss__pagination__page--next, .ss__load-more__button').first().click({ force: true });
+			cy.get('.ss__pagination__page--next, .ss__load-more__button').should('exist').first().click({ force: true });
 			cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 2));
 			cy.snapController().then(({ store }) => {
 				expect(store.results.length).to.equal(resultsPerPage * 2);
@@ -75,14 +77,14 @@ describe('Infinite Setting Test', () => {
 
 			//refresh page, should backfill
 			cy.reload().then(() => {
+				cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 2));
 				cy.snapController().then(({ store }) => {
 					expect(store.results.length).to.equal(resultsPerPage * 2);
 				});
 			});
 
 			// click next page again, expect 3 pages of results
-			cy.get('.ss__pagination__page--next, .ss__load-more__button').first().click({ force: true });
-			cy.wait(100);
+			cy.get('.ss__pagination__page--next, .ss__load-more__button').should('exist').first().click({ force: true });
 			cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage * 3));
 			cy.snapController().then(({ store }) => {
 				expect(store.results.length).to.equal(resultsPerPage * 3);
@@ -91,6 +93,7 @@ describe('Infinite Setting Test', () => {
 
 			//refresh page, should NOT backfill again due to page > backfill and is at page 1
 			cy.reload().then(() => {
+				cy.waitUntil(() => cy.get('.ss__result').should('have.length', resultsPerPage));
 				cy.snapController().then(({ store }) => {
 					expect(store.results.length).to.equal(resultsPerPage);
 					expect(store.pagination.current.number).to.equal(1);


### PR DESCRIPTION
This pull request refactors and improves the reliability of Cypress end-to-end tests in the `snap-preact-demo` package. The main changes focus on simplifying test logic for clicking result links and waiting for navigation, as well as making infinite scroll tests more robust by ensuring elements exist before interacting and waiting for results to load. These updates improve test stability and readability.

**Test reliability and robustness improvements:**

* Updated all "can click on a result and go to that page" tests to directly retrieve the link's `href` attribute and assert navigation, removing unnecessary use of `cy.document()` and internal query selectors. This simplifies the tests and avoids potential flakiness. [[1]](diffhunk://#diff-ceaf75c5a43a4f43565ad41ca684d0d11e6c9faf08a1c1b204d740ef0407c740L184-L196) [[2]](diffhunk://#diff-3a942c98d610829dfac8b5bc63b8024d9e326358de41280ae4b0c6068be80612L212-L225) [[3]](diffhunk://#diff-e311afa434e83a45b58e3d3ca9a1b79ace4fe534add1567622d1dfde22aa18f1L119-L131) [[4]](diffhunk://#diff-1c6da8b94329855190c89cf6cedaa3ea711bb8d3e1ae9f055e5dd3e4b298371dL155-R159) [[5]](diffhunk://#diff-37b7bf6df0e5aa1fb90bc745bd9208ad2d6ca3ab772ecab6d3c20347ff7fa56eL147-L159) [[6]](diffhunk://#diff-317e3f1408bdbf87e099b04e894d6df5cd347bdd74faa5e7b9a50064cf979af7L53-R57) [[7]](diffhunk://#diff-7fd2555b37be7602ebd88ba7cfe486823969f5a2437ec085ef26feebc2d0a33aL53-R57)
* In infinite scroll tests (`infinite.cy.js`), added explicit waits using `cy.waitUntil` after pagination actions and page reloads to ensure the expected number of results are present before continuing. Also added checks to ensure pagination buttons exist before clicking. This reduces timing-related test failures. [[1]](diffhunk://#diff-422216e1518028dfdbe730f45d9c05df92b7ecb40a535dcd8dbebab8f7d32df7L31-R32) [[2]](diffhunk://#diff-422216e1518028dfdbe730f45d9c05df92b7ecb40a535dcd8dbebab8f7d32df7R41) [[3]](diffhunk://#diff-422216e1518028dfdbe730f45d9c05df92b7ecb40a535dcd8dbebab8f7d32df7L69-R71) [[4]](diffhunk://#diff-422216e1518028dfdbe730f45d9c05df92b7ecb40a535dcd8dbebab8f7d32df7R80-R87) [[5]](diffhunk://#diff-422216e1518028dfdbe730f45d9c05df92b7ecb40a535dcd8dbebab8f7d32df7R96) [[6]](diffhunk://#diff-ff1f94a13a6355af38e9ee675b0822bfcbac327dd81e1f0fa9f86f88acea9477L31-R32) [[7]](diffhunk://#diff-ff1f94a13a6355af38e9ee675b0822bfcbac327dd81e1f0fa9f86f88acea9477R41) [[8]](diffhunk://#diff-ff1f94a13a6355af38e9ee675b0822bfcbac327dd81e1f0fa9f86f88acea9477L69-R71) [[9]](diffhunk://#diff-ff1f94a13a6355af38e9ee675b0822bfcbac327dd81e1f0fa9f86f88acea9477R80-R87) [[10]](diffhunk://#diff-ff1f94a13a6355af38e9ee675b0822bfcbac327dd81e1f0fa9f86f88acea9477R96)

**Test code simplification:**

* Removed redundant `.then(({ store }) => { ... })` and `.document()` blocks from tests, streamlining test code and focusing on user-visible interactions. [[1]](diffhunk://#diff-ceaf75c5a43a4f43565ad41ca684d0d11e6c9faf08a1c1b204d740ef0407c740L184-L196) [[2]](diffhunk://#diff-3a942c98d610829dfac8b5bc63b8024d9e326358de41280ae4b0c6068be80612L212-L225) [[3]](diffhunk://#diff-e311afa434e83a45b58e3d3ca9a1b79ace4fe534add1567622d1dfde22aa18f1L119-L131) [[4]](diffhunk://#diff-1c6da8b94329855190c89cf6cedaa3ea711bb8d3e1ae9f055e5dd3e4b298371dL155-R159) [[5]](diffhunk://#diff-37b7bf6df0e5aa1fb90bc745bd9208ad2d6ca3ab772ecab6d3c20347ff7fa56eL147-L159) [[6]](diffhunk://#diff-317e3f1408bdbf87e099b04e894d6df5cd347bdd74faa5e7b9a50064cf979af7L53-R57) [[7]](diffhunk://#diff-7fd2555b37be7602ebd88ba7cfe486823969f5a2437ec085ef26feebc2d0a33aL53-R57)

**Autocomplete test improvements:**

* Added calls to `cy.addLocalSnap()` and `cy.waitForBundle()` before running autocomplete tests to ensure the Snap is installed and ready, and improved input field selection with timeouts and force-clicks for better reliability.

These changes collectively improve test maintainability, reliability, and readability.