### PR TITLE
feat: adding displayType to facet props

### DIFF
--- a/packages/snap-preact/components/src/components/Organisms/Facet/Facet.stories.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Facet/Facet.stories.tsx
@@ -422,6 +422,20 @@ export default {
 				type: 'object',
 			},
 		},
+		displayType: {
+			description:
+				'Override the API display type used to render the facet options - only list, grid and palette are interchangeable; misaligned overrides fall back to the API display type',
+			table: {
+				category: 'Templates Legal',
+				type: {
+					summary: 'string',
+				},
+			},
+			control: {
+				type: 'select',
+			},
+			options: ['list', 'grid', 'palette'],
+		},
 		...componentArgs,
 	},
 };

--- a/packages/snap-preact/components/src/components/Organisms/Facet/Facet.test.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Facet/Facet.test.tsx
@@ -121,6 +121,108 @@ describe('Facet Component', () => {
 		});
 	});
 
+	describe('displayType prop', () => {
+		it('overrides the API display type', () => {
+			const args: FacetProps = {
+				facet: { ...paletteFacetMock, display: 'palette' } as ValueFacet,
+				displayType: 'list',
+			};
+			// @ts-ignore - readonly
+			args.facet.refinedValues = (args.facet as ValueFacet).values;
+			const rendered = render(<Facet {...args} />);
+			const facetElement = rendered.container.querySelector('.ss__facet');
+			expect(facetElement).toHaveClass('ss__facet--list');
+			expect(facetElement).not.toHaveClass('ss__facet--palette');
+			const count = rendered.container.querySelectorAll('.ss__facet-list-options__option').length;
+			expect(count).toEqual((args.facet as ValueFacet).values.length);
+			expect(rendered.container.querySelector('.ss__facet-palette-options')).not.toBeInTheDocument();
+		});
+
+		it('cannot override a hierarchy display and falls back to the API display', () => {
+			const args: FacetProps = {
+				facet: { ...hierarchyFacetMock, display: 'hierarchy' } as ValueFacet,
+				displayType: 'palette',
+			};
+			args.facet.collapsed = false;
+			const rendered = render(<Facet {...args} />);
+			expect(rendered.container.querySelector('.ss__facet')).toHaveClass('ss__facet--hierarchy');
+			expect(rendered.container.querySelector('.ss__facet-hierarchy-options')).toBeInTheDocument();
+			expect(rendered.container.querySelector('.ss__facet-palette-options')).not.toBeInTheDocument();
+		});
+
+		it('cannot override to a hierarchy display and falls back to the API display', () => {
+			const args: FacetProps = {
+				facet: { ...listFacetMock, display: 'list' } as ValueFacet,
+				//@ts-ignore - hierarchy is not an allowed displayType, testing runtime fallback for untyped theme configs
+				displayType: 'hierarchy',
+			};
+			const rendered = render(<Facet {...args} />);
+			expect(rendered.container.querySelector('.ss__facet')).toHaveClass('ss__facet--list');
+			expect(rendered.container.querySelector('.ss__facet-list-options')).toBeInTheDocument();
+			expect(rendered.container.querySelector('.ss__facet-hierarchy-options')).not.toBeInTheDocument();
+		});
+
+		it('cannot override a slider display', () => {
+			const args: FacetProps = {
+				//@ts-ignore - mock data type
+				facet: { ...sliderFacetMock, display: 'slider' } as RangeFacet,
+				displayType: 'list',
+			};
+			args.facet.collapsed = false;
+			const rendered = render(<Facet {...args} />);
+			expect(rendered.container.querySelector('.ss__facet')).toHaveClass('ss__facet--slider');
+			expect(rendered.container.querySelector('.ss__facet-slider')).toBeInTheDocument();
+			expect(rendered.container.querySelector('.ss__facet-list-options')).not.toBeInTheDocument();
+		});
+
+		it('applies display keyed props using the overridden display type', () => {
+			const args: FacetProps = {
+				facet: { ...facetOverflowMock, display: 'list' } as ValueFacet,
+				displayType: 'grid',
+				disableOverflow: true,
+				display: {
+					grid: { limit: 3 },
+					list: { limit: 1 },
+				},
+			};
+			const rendered = render(<Facet {...args} />);
+			const count = rendered.container.querySelectorAll('.ss__facet-grid-options__option').length;
+			expect(count).toEqual(3);
+		});
+
+		it('can be set per field via the fields prop', () => {
+			const args: FacetProps = {
+				facet: { ...paletteFacetMock, display: 'palette' } as ValueFacet,
+				fields: {
+					[paletteFacetMock.field!]: { displayType: 'grid' },
+				},
+			};
+			const rendered = render(<Facet {...args} />);
+			expect(rendered.container.querySelector('.ss__facet')).toHaveClass('ss__facet--grid');
+			expect(rendered.container.querySelector('.ss__facet-grid-options')).toBeInTheDocument();
+		});
+
+		it('is themeable', () => {
+			const globalTheme = {
+				components: {
+					facet: {
+						displayType: 'list' as const,
+					},
+				},
+			};
+			const args: FacetProps = {
+				facet: { ...paletteFacetMock, display: 'palette' } as ValueFacet,
+			};
+			const rendered = render(
+				<ThemeProvider theme={globalTheme}>
+					<Facet {...args} />
+				</ThemeProvider>
+			);
+			expect(rendered.container.querySelector('.ss__facet')).toHaveClass('ss__facet--list');
+			expect(rendered.container.querySelector('.ss__facet-list-options')).toBeInTheDocument();
+		});
+	});
+
 	describe('Facet props', () => {
 		it('color prop', () => {
 			const args = {

--- a/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
@@ -148,11 +148,24 @@ export const Facet = observer((properties: FacetProps) => {
 
 	let props = mergeProps('facet', globalTheme, defaultProps, properties);
 
+	// resolves the rendered display type - the displayType prop overrides the API display, but only
+	// list, grid and palette are interchangeable; other displays (slider, hierarchy, toggle) have data
+	// requirements that must match the API display, so misaligned overrides fall back to the API display
+	const interchangeableDisplays: string[] = [FacetDisplay.LIST, FacetDisplay.GRID, FacetDisplay.PALETTE];
+	const resolveDisplayType = () => {
+		const apiDisplay = props.facet?.display;
+		if (props.displayType && interchangeableDisplays.includes(apiDisplay) && interchangeableDisplays.includes(props.displayType)) {
+			return props.displayType;
+		}
+		return apiDisplay;
+	};
+	let displayType = resolveDisplayType();
+
 	//manual props override on a per facet display type level using the display prop
-	if (props.display && props.display[props.facet?.display]) {
+	if (props.display && props.display[displayType]) {
 		props = {
 			...props,
-			...props.display[props.facet?.display],
+			...props.display[displayType],
 		};
 	}
 
@@ -163,6 +176,9 @@ export const Facet = observer((properties: FacetProps) => {
 			...props.fields[props.facet?.field],
 		};
 	}
+
+	// re-resolve in case the display or fields overrides set a displayType
+	displayType = resolveDisplayType();
 
 	const {
 		disableCollapse,
@@ -460,6 +476,7 @@ export const Facet = observer((properties: FacetProps) => {
 		className,
 		internalClassName,
 		...props,
+		displayType,
 	};
 
 	//initialize lang
@@ -506,7 +523,7 @@ export const Facet = observer((properties: FacetProps) => {
 					`${facet.collapsed ? 'ss__facet--collapsed' : ''}`,
 					className,
 					internalClassName,
-					`${facet.display ? `ss__facet--${facet.display}` : ''}`,
+					`${displayType ? `ss__facet--${displayType}` : ''}`,
 					(statefulOverflow ? overflowState?.remaining || 0 > 0 : ((facet as ValueFacet)?.overflow?.remaining || 0) > 0) || facet?.display == 'slider'
 						? ''
 						: 'ss__facet--showing-all'
@@ -571,7 +588,8 @@ export const Facet = observer((properties: FacetProps) => {
 });
 
 const FacetContent = (
-	props: FacetProps & {
+	props: Omit<FacetProps, 'displayType'> & {
+		displayType?: string;
 		limitedValues: (FacetHierarchyValue | FacetValue | FacetRangeValue | undefined)[];
 		searchableFacet: {
 			allowableTypes: string[];
@@ -607,6 +625,7 @@ const FacetContent = (
 		hideShowMoreLessText,
 		treePath,
 		mergedLang,
+		displayType,
 	} = props;
 
 	const [low, setLow] = useState<number | undefined>(
@@ -650,7 +669,7 @@ const FacetContent = (
 
 	return (
 		<>
-			{searchable && searchableFacet.allowableTypes.includes(facet.display) && (
+			{searchable && searchableFacet.allowableTypes.includes(displayType || facet.display) && (
 				<SearchInput
 					{...subProps.searchInput}
 					onChange={searchableFacet.searchFilter}
@@ -664,7 +683,7 @@ const FacetContent = (
 					if (optionsSlot) {
 						return cloneWithProps(optionsSlot, { facet, valueProps, limit, previewOnFocus, treePath });
 					} else {
-						switch (facet?.display) {
+						switch (displayType || facet?.display) {
 							// case FacetDisplay.TOGGLE:
 							// 	return <FacetToggle {...subProps.facetToggle} facet={facet as ValueFacet} />;
 							case FacetDisplay.SLIDER:
@@ -853,6 +872,7 @@ export type FacetTemplatesLegalProps = {
 	iconOverflowLess?: IconType | Partial<IconProps>;
 	fields?: FieldProps;
 	display?: FieldProps;
+	displayType?: `${FacetDisplay.GRID}` | `${FacetDisplay.PALETTE}` | `${FacetDisplay.LIST}`;
 	searchable?: boolean;
 	rangeInputs?: boolean;
 	rangeInputsSubmitButtonText?: string;

--- a/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
@@ -593,7 +593,7 @@ const FacetContent = (
 	props: Omit<FacetProps, 'displayType'> & {
 		// wider than the public displayType prop, as the resolved value can also be a display type that
 		// is not interchangeable (eg. slider, hierarchy)
-		displayType?: ResolvedFacetDisplay;
+		displayType: ResolvedFacetDisplay;
 		limitedValues: (FacetHierarchyValue | FacetValue | FacetRangeValue | undefined)[];
 		searchableFacet: {
 			allowableTypes: string[];
@@ -673,7 +673,7 @@ const FacetContent = (
 
 	return (
 		<>
-			{searchable && searchableFacet.allowableTypes.includes(displayType || facet.display) && (
+			{searchable && searchableFacet.allowableTypes.includes(displayType) && (
 				<SearchInput
 					{...subProps.searchInput}
 					onChange={searchableFacet.searchFilter}
@@ -687,7 +687,7 @@ const FacetContent = (
 					if (optionsSlot) {
 						return cloneWithProps(optionsSlot, { facet, valueProps, limit, previewOnFocus, treePath });
 					} else {
-						switch (displayType || facet?.display) {
+						switch (displayType) {
 							// case FacetDisplay.TOGGLE:
 							// 	return <FacetToggle {...subProps.facetToggle} facet={facet as ValueFacet} />;
 							case FacetDisplay.SLIDER:

--- a/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
+++ b/packages/snap-preact/components/src/components/Organisms/Facet/Facet.tsx
@@ -152,8 +152,10 @@ export const Facet = observer((properties: FacetProps) => {
 	// list, grid and palette are interchangeable; other displays (slider, hierarchy, toggle) have data
 	// requirements that must match the API display, so misaligned overrides fall back to the API display
 	const interchangeableDisplays: string[] = [FacetDisplay.LIST, FacetDisplay.GRID, FacetDisplay.PALETTE];
-	const resolveDisplayType = () => {
-		const apiDisplay = props.facet?.display;
+	const resolveDisplayType = (): ResolvedFacetDisplay => {
+		// the store types display as a plain string, so it is narrowed here - the options switch renders
+		// its default case for any value outside of FacetDisplay
+		const apiDisplay = props.facet?.display as ResolvedFacetDisplay;
 		if (props.displayType && interchangeableDisplays.includes(apiDisplay) && interchangeableDisplays.includes(props.displayType)) {
 			return props.displayType;
 		}
@@ -589,7 +591,9 @@ export const Facet = observer((properties: FacetProps) => {
 
 const FacetContent = (
 	props: Omit<FacetProps, 'displayType'> & {
-		displayType?: string;
+		// wider than the public displayType prop, as the resolved value can also be a display type that
+		// is not interchangeable (eg. slider, hierarchy)
+		displayType?: ResolvedFacetDisplay;
 		limitedValues: (FacetHierarchyValue | FacetValue | FacetRangeValue | undefined)[];
 		searchableFacet: {
 			allowableTypes: string[];
@@ -872,7 +876,7 @@ export type FacetTemplatesLegalProps = {
 	iconOverflowLess?: IconType | Partial<IconProps>;
 	fields?: FieldProps;
 	display?: FieldProps;
-	displayType?: `${FacetDisplay.GRID}` | `${FacetDisplay.PALETTE}` | `${FacetDisplay.LIST}`;
+	displayType?: InterchangeableFacetDisplay;
 	searchable?: boolean;
 	rangeInputs?: boolean;
 	rangeInputsSubmitButtonText?: string;
@@ -882,6 +886,12 @@ export type FacetTemplatesLegalProps = {
 	justContent?: boolean;
 	horizontal?: boolean;
 };
+
+// display types that can be swapped for one another via the displayType prop
+export type InterchangeableFacetDisplay = `${FacetDisplay.GRID}` | `${FacetDisplay.PALETTE}` | `${FacetDisplay.LIST}`;
+
+// the display type a facet renders with, once the displayType prop has been resolved against the API display
+export type ResolvedFacetDisplay = `${FacetDisplay}`;
 
 export interface FacetLang {
 	showMoreText: Lang<{

--- a/packages/snap-preact/components/src/components/Organisms/Facet/readme.md
+++ b/packages/snap-preact/components/src/components/Organisms/Facet/readme.md
@@ -261,6 +261,33 @@ const displayProp = {
 <Facet facet={controller.store.facets[0]} display={displayProp} />
 ```
 
+### displayType
+The `displayType` prop overrides the display type provided by the meta API, changing which options component the facet renders with. Accepts `'list'`, `'grid'`, or `'palette'` — only these display types are interchangeable. If the facet's API display type is not one of these (eg. `'slider'`, `'hierarchy'`), or the override value is not one of these, the prop is ignored and the API display type is used. Note that while a `'palette'` facet can be displayed as any of the other types, fields not intended for palette display may not render well as a palette (option values are used as swatch colors).
+
+```tsx
+<Facet facet={controller.store.facets[0]} displayType={'list'} />
+```
+
+When using Snap Templates, `displayType` can be set via theme overrides — including responsively per breakpoint and scoped to a specific component tree. For example, to render autocomplete facets as a list across all breakpoints while keeping the API display type (eg. `palette`) on desktop and everywhere in search:
+
+```typescript
+new SnapTemplates({
+	config: {
+		theme: {
+			extends: 'pike',
+			overrides: {
+				default: {
+					'autocompleteFixed facet': {
+						displayType: 'list',
+					},
+				},
+			},
+		},
+	},
+	// ...
+});
+```
+
 ### optionsSlot
 The `optionsSlot` prop is a JSX element used to manually set the options component used, regardless of the facet.display type. Returns the facet,valueProps, limit, & previewOnFocus prop values.
 


### PR DESCRIPTION
This pull request adds a new `displayType` prop to the `Facet` component, allowing consumers to override the API-provided display type for facets. The override is only allowed for interchangeable display types (`list`, `grid`, and `palette`); for other types, the component falls back to the API display type. The change is fully documented, tested, and integrated with theme and field-level overrides.

**Display Type Override Functionality:**

- Added `displayType` prop to `Facet`, allowing the display type to be overridden for interchangeable types (`list`, `grid`, `palette`). The prop is ignored for non-interchangeable types, ensuring correct rendering for facets that require specific data structures (e.g., `slider`, `hierarchy`). [[1]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bR151-R168) [[2]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bR180-R182) [[3]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bL509-R526) [[4]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bL653-R672) [[5]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bL667-R686) [[6]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bR875)

- Updated the class names and rendering logic throughout `Facet` to use the resolved display type, ensuring UI consistency with the override. [[1]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bL509-R526) [[2]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bL653-R672) [[3]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bL667-R686)

**Theming and Field-Level Overrides:**

- Integrated `displayType` with theming and field-level overrides, so it can be set globally, per field, or via Snap Templates theme configuration. [[1]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bR151-R168) [[2]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bR180-R182) [[3]](diffhunk://#diff-c6ed9b327b41b47133aa07b3288e85c9b7406a6d84073e687fb5bba5f9e3248bR479)

**Documentation:**

- Added documentation for the new `displayType` prop in the Facet README, including usage examples and caveats.

**Testing:**

- Added comprehensive tests for `displayType` in `Facet.test.tsx`, covering direct prop usage, fallback behavior, theming, and field-level overrides.

**Storybook/Docs Integration:**

- Added `displayType` to Facet's Storybook controls for easier exploration and testing.